### PR TITLE
Fix crash on shutdown

### DIFF
--- a/scalopus_catapult/src/scalopus_catapult_server.cpp
+++ b/scalopus_catapult/src/scalopus_catapult_server.cpp
@@ -30,6 +30,7 @@
 
 #include <scalopus_general/general_provider.h>
 #include <scalopus_tracing/endpoint_native_trace_sender.h>
+#include <scalopus_tracing/endpoint_trace_configurator.h>
 #include <scalopus_tracing/lttng_provider.h>
 #include <scalopus_tracing/native_trace_provider.h>
 #include <scalopus_transport/transport_unix.h>
@@ -99,6 +100,11 @@ int main(int argc, char** argv)
 
   // Add endpoint factory function for the process information.
   manager->addEndpointFactory<scalopus::EndpointProcessInfo>();
+
+  // Adding this endpoint, just to prevent it from complaining for now.
+  // In the future we could use this endpoint to toggle threads from the UI, but the UI's support for this is quite
+  // poor, and once a setting is seen it will be present indefinitely.
+  manager->addEndpointFactory<scalopus::EndpointTraceConfigurator>();
 
   auto native_trace_provider = std::make_shared<scalopus::NativeTraceProvider>(manager);
   manager->addEndpointFactory(scalopus::EndpointNativeTraceSender::name, native_trace_provider);

--- a/scalopus_examples/src/query_servers.cpp
+++ b/scalopus_examples/src/query_servers.cpp
@@ -88,6 +88,18 @@ int main(int /* argc */, char** /* argv */)
         continue;
       }
 
+      if (name == scalopus::EndpointTraceConfigurator::name)
+      {
+        auto client = std::make_shared<scalopus::EndpointTraceConfigurator>();
+        client->setTransport(transport);
+        const auto state = client->getTraceState();
+        server_info[scalopus::EndpointTraceConfigurator::name] = { { "process_state", state.process_state },
+                                                                   { "thread_state", state.thread_state },
+                                                                   { "cmd_success", state.cmd_success } };
+        std::cerr << "  process_state:     " << state.process_state << std::endl;
+        continue;
+      }
+
       if (name == scalopus::EndpointTraceMapping::name)
       {
         auto client = std::make_shared<scalopus::EndpointTraceMapping>();

--- a/scalopus_examples/src/random_callstacks.cpp
+++ b/scalopus_examples/src/random_callstacks.cpp
@@ -119,6 +119,7 @@ int main(int argc, char** argv)
   const auto server = factory->serve();
   server->addEndpoint(std::make_unique<scalopus::EndpointTraceMapping>());
   server->addEndpoint(std::make_unique<scalopus::EndpointIntrospect>());
+  server->addEndpoint(std::make_unique<scalopus::EndpointTraceConfigurator>());
   auto endpoint_process_info = std::make_shared<scalopus::EndpointProcessInfo>();
   endpoint_process_info->setProcessName(argv[0]);
   server->addEndpoint(endpoint_process_info);

--- a/scalopus_general/include/scalopus_general/map_tracker.h
+++ b/scalopus_general/include/scalopus_general/map_tracker.h
@@ -30,7 +30,7 @@
 #ifndef SCALOPUS_SCOPE_MAP_TRACKER_H
 #define SCALOPUS_SCOPE_MAP_TRACKER_H
 
-#include <map>
+#include <unordered_map>
 #include <shared_mutex>
 #include <string>
 
@@ -61,7 +61,7 @@ public:
    * @brief Function to retrieve the mapping between entry and exit ids and provided names.
    * @return Map that holds trace point id - trace name mapping.
    */
-  std::map<Key, Value> getMap() const
+  std::unordered_map<Key, Value> getMap() const
   {
     std::shared_lock<decltype(mutex_)> lock(mutex_);
     return mapping_;
@@ -95,7 +95,7 @@ public:
   }
 
 private:
-  std::map<Key, Value> mapping_;
+  std::unordered_map<Key, Value> mapping_;
   mutable std::shared_timed_mutex mutex_;  //! Mutex for the mapping container.
 
 protected:

--- a/scalopus_general/include/scalopus_general/map_tracker.h
+++ b/scalopus_general/include/scalopus_general/map_tracker.h
@@ -68,10 +68,10 @@ public:
   }
 
   /**
-   * @brief Retrieve a key from the map, the caller is responsible for ensuring the key exists.
-   * @return The value stored for this key.
+   * @brief Retrieve a value from the map by key, the caller is responsible for ensuring the key exists.
+   * @return A copy of the value stored.
    */
-  Value getKey(const Key& k) const
+  Value getValue(const Key& k) const
   {
     std::shared_lock<decltype(mutex_)> lock(mutex_);
     return mapping_.at(k);

--- a/scalopus_general/include/scalopus_general/map_tracker.h
+++ b/scalopus_general/include/scalopus_general/map_tracker.h
@@ -68,6 +68,16 @@ public:
   }
 
   /**
+   * @brief Retrieve a key from the map, the caller is responsible for ensuring the key exists.
+   * @return The value stored for this key.
+   */
+  Value getKey(const Key& k) const
+  {
+    std::shared_lock<decltype(mutex_)> lock(mutex_);
+    return mapping_.at(k);
+  }
+
+  /**
    * @brief Return true if a key already exists, return false if the key doesn't exist.
    */
   bool exists(const Key& k) const

--- a/scalopus_python/lib/scalopus_general.cpp
+++ b/scalopus_python/lib/scalopus_general.cpp
@@ -50,7 +50,15 @@ void add_scalopus_general(py::module& m)
 
   py::class_<EndpointProcessInfo::ProcessInfo> endpoint_process_info_info(general, "ProcessInfo");
   endpoint_process_info_info.def_readwrite("name", &EndpointProcessInfo::ProcessInfo::name);
+  endpoint_process_info_info.def_readwrite("pid", &EndpointProcessInfo::ProcessInfo::pid);
   endpoint_process_info_info.def_readwrite("threads", &EndpointProcessInfo::ProcessInfo::threads);
+  endpoint_process_info_info.def("to_dict", [](const EndpointProcessInfo::ProcessInfo& p) {
+    auto dict = py::dict();
+    dict["name"] = p.name;
+    dict["threads"] = p.threads;
+    dict["pid"] = p.pid;
+    return dict;
+  });
 
   py::class_<EndpointProcessInfo, EndpointProcessInfo::Ptr, Endpoint> endpoint_process_info(general,
                                                                                             "EndpointProcessInfo");
@@ -70,6 +78,7 @@ void add_scalopus_general(py::module& m)
   endpoint_manager_poll.def("stopPolling", &EndpointManagerPoll::stopPolling);
   endpoint_manager_poll.def("manage", &EndpointManagerPoll::manage);
   endpoint_manager_poll.def("setLogger", &EndpointManagerPoll::setLogger);
+  endpoint_manager_poll.def("endpoints", &EndpointManagerPoll::endpoints);
 
   // General provider.
   py::class_<GeneralProvider, GeneralProvider::Ptr, TraceEventProvider> general_provider(general, "GeneralProvider");

--- a/scalopus_python/lib/scalopus_interface.cpp
+++ b/scalopus_python/lib/scalopus_interface.cpp
@@ -181,6 +181,7 @@ void add_scalopus_interface(py::module& m)
   py::class_<Transport, Transport::Ptr> transport_interface(interface, "Transport");
   transport_interface.def("addEndpoint", &Transport::addEndpoint, py::keep_alive<1, 2>());
   transport_interface.def("isConnected", &Transport::isConnected);
+  transport_interface.def("getAddress", &Transport::getAddress);
   transport_interface.def("broadcast", &Transport::broadcast);
   transport_interface.def("request", [](Transport& transport, const std::string& name, const py::object& outgoing) {
     return std::make_shared<PendingResponse>(transport.request(name, pyToData(outgoing)));

--- a/scalopus_python/lib/scalopus_tracing.cpp
+++ b/scalopus_python/lib/scalopus_tracing.cpp
@@ -62,6 +62,7 @@ void add_scalopus_tracing(py::module& m)
       .value("PROCESS", MarkLevel::PROCESS)
       .value("THREAD", MarkLevel::THREAD);
 
+  // Start EndpointTraceMapping
   py::class_<EndpointTraceMapping, EndpointTraceMapping::Ptr, Endpoint> endpoint_trace_mapping(tracing,
                                                                                                "EndpointTraceMapping");
   endpoint_trace_mapping.def(py::init<>());
@@ -69,6 +70,39 @@ void add_scalopus_tracing(py::module& m)
   endpoint_trace_mapping.def_static("factory", &EndpointTraceMapping::factory);
   endpoint_trace_mapping.def_property_readonly_static("name",
                                                       [](py::object /* self */) { return EndpointTraceMapping::name; });
+  // End EndpointTraceMapping
+
+  // Start EndpointTraceConfigurator
+
+  py::class_<EndpointTraceConfigurator, EndpointTraceConfigurator::Ptr, Endpoint> endpoint_tc(
+      tracing, "EndpointTraceConfigurator");
+  endpoint_tc.def(py::init<>());
+  endpoint_tc.def("setTraceState", &EndpointTraceConfigurator::setTraceState);
+  endpoint_tc.def("getTraceState", &EndpointTraceConfigurator::getTraceState);
+  endpoint_tc.def_property_readonly_static("name",
+                                           [](py::object /* self */) { return EndpointTraceConfigurator::name; });
+  endpoint_tc.def_static("factory", &EndpointTraceConfigurator::factory);
+
+  py::class_<EndpointTraceConfigurator::TraceConfiguration> endpoint_tc_trace_conf(endpoint_tc, "TraceConfiguration");
+  endpoint_tc_trace_conf.def(py::init<>());
+  endpoint_tc_trace_conf.def_readwrite("process_state", &EndpointTraceConfigurator::TraceConfiguration::process_state);
+  endpoint_tc_trace_conf.def_readwrite("cmd_success", &EndpointTraceConfigurator::TraceConfiguration::cmd_success);
+  endpoint_tc_trace_conf.def_readwrite("set_process_state",
+                                       &EndpointTraceConfigurator::TraceConfiguration::set_process_state);
+  endpoint_tc_trace_conf.def_readwrite("thread_state", &EndpointTraceConfigurator::TraceConfiguration::thread_state);
+  // For some reason, assigning into tread_state directly didn't work, make a simple assign function.
+  endpoint_tc_trace_conf.def("add_thread_entry", [](EndpointTraceConfigurator::TraceConfiguration& v, unsigned long id,
+                                                    bool state) { v.thread_state[id] = state; });
+
+  endpoint_tc_trace_conf.def("to_dict", [](const EndpointTraceConfigurator::TraceConfiguration& p) {
+    auto dict = py::dict();
+    dict["set_process_state"] = p.set_process_state;
+    dict["process_state"] = p.process_state;
+    dict["cmd_success"] = p.cmd_success;
+    dict["thread_state"] = p.thread_state;
+    return dict;
+  });
+  // End EndpointTraceConfigurator
 
   py::module native = tracing.def_submodule("native", "The native specific components.");
   py::class_<EndpointNativeTraceSender, EndpointNativeTraceSender::Ptr, Endpoint> endpoint_native_trace_sender(

--- a/scalopus_python/lib/scalopus_tracing.cpp
+++ b/scalopus_python/lib/scalopus_tracing.cpp
@@ -82,20 +82,20 @@ void add_scalopus_tracing(py::module& m)
   });
 
   tracing.def("getThreadState", []() {
-    TraceConfigurator& configurator = TraceConfigurator::getInstance();
-    return configurator.getThreadState();
+    auto configurator = TraceConfigurator::getInstance();
+    return configurator->getThreadState();
   });
   tracing.def("setThreadState", [](bool new_state) {
-    TraceConfigurator& configurator = TraceConfigurator::getInstance();
-    return configurator.setThreadState(new_state);
+    auto configurator = TraceConfigurator::getInstance();
+    return configurator->setThreadState(new_state);
   });
   tracing.def("getProcessState", []() {
-    TraceConfigurator& configurator = TraceConfigurator::getInstance();
-    return configurator.getProcessState();
+    auto configurator = TraceConfigurator::getInstance();
+    return configurator->getProcessState();
   });
   tracing.def("setProcessState", [](bool new_state) {
-    TraceConfigurator& configurator = TraceConfigurator::getInstance();
-    return configurator.setProcessState(new_state);
+    auto configurator = TraceConfigurator::getInstance();
+    return configurator->setProcessState(new_state);
   });
 
 #ifdef SCALOPUS_TRACING_HAVE_LTTNG

--- a/scalopus_python/scalopus/__main__.py
+++ b/scalopus_python/scalopus/__main__.py
@@ -27,7 +27,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from . import tracing, general, transport, common, interface, lib
+import scalopus
 
 import sys
 import argparse
@@ -35,22 +35,24 @@ import time
 
 def run_catapult_server(args):
     # Embedding catapult server
-    factory = transport.TransportUnixFactory()
-    poller = general.EndpointManagerPoll(factory)
-    native_provider = tracing.native.NativeTraceProvider(poller)
+    factory = scalopus.transport.TransportUnixFactory()
+    poller = scalopus.general.EndpointManagerPoll(factory)
+    native_provider = scalopus.tracing.native.NativeTraceProvider(poller)
 
-    poller.addEndpointFactory(tracing.EndpointNativeTraceSender.name,
+    poller.addEndpointFactory(scalopus.tracing.EndpointNativeTraceSender.name,
                               native_provider.factory)
-    poller.addEndpointFactory(tracing.EndpointTraceMapping.name,
-                              tracing.EndpointTraceMapping.factory)
-    poller.addEndpointFactory(general.EndpointProcessInfo.name,
-                              general.EndpointProcessInfo.factory)
+    poller.addEndpointFactory(scalopus.tracing.EndpointTraceMapping.name,
+                              scalopus.tracing.EndpointTraceMapping.factory)
+    poller.addEndpointFactory(scalopus.general.EndpointProcessInfo.name,
+                              scalopus.general.EndpointProcessInfo.factory)
+    poller.addEndpointFactory(scalopus.tracing.EndpointTraceConfigurator.name,
+                              scalopus.tracing.EndpointTraceConfigurator.factory)
 
     poller.startPolling(args.poll_interval)  # Start polling at interval.
 
-    catapult = lib.catapult.CatapultServer()
+    catapult = scalopus.lib.catapult.CatapultServer()
     catapult.addProvider(native_provider)
-    general_provider = general.GeneralProvider(poller)
+    general_provider = scalopus.general.GeneralProvider(poller)
     catapult.addProvider(general_provider)
 
     def logger(s):
@@ -62,8 +64,8 @@ def run_catapult_server(args):
     if (args.poll_log):
         poller.setLogger(logger)
 
-    if tracing.have_lttng:
-        lttng_provider = tracing.lttng.LttngProvider(args.lttng_session,
+    if scalopus.tracing.have_lttng:
+        lttng_provider = scalopus.tracing.lttng.LttngProvider(args.lttng_session,
                                                      poller)
         catapult.addProvider(lttng_provider)
 
@@ -75,6 +77,113 @@ def run_catapult_server(args):
             time.sleep(10)
     except KeyboardInterrupt:
         pass
+
+def run_discover(args):
+    factory = scalopus.transport.TransportUnixFactory()
+    poller = scalopus.general.EndpointManagerPoll(factory)
+    poller.addEndpointFactory(scalopus.general.EndpointProcessInfo.name,
+                              scalopus.general.EndpointProcessInfo.factory)
+    # Perform just one discovery round
+    poller.manage()
+
+    # Retrieve active endpoints
+    endpoints = poller.endpoints()
+
+    entries = []
+    for endpoint_map in endpoints.values():
+        data = {}
+        for endpoint in endpoint_map.values():
+            if isinstance(endpoint, scalopus.general.EndpointProcessInfo):
+                pinfo = endpoint.processInfo()
+                data["pid"] = pinfo.pid
+                data["process_info"] = pinfo.to_dict()
+            if isinstance(endpoint, scalopus.general.EndpointIntrospect):
+                data["supported"] = endpoint.supported()
+        entries.append((data["pid"], data))
+
+    entries.sort()
+
+    for _, data in entries:
+        print("PID: {pid: >6d}  \"{name}\"".format(**data["process_info"]))
+        doffset = " " * 13
+        print(doffset + "Endpoints: {}".format(
+              ("\n" + doffset + "  ").join([""] + sorted(data["supported"]))))
+        threads = data["process_info"]["threads"]
+        if threads:
+            print(doffset + "Threads:")
+            for thread_id, thread_name in sorted(threads.items()):
+                print(doffset + "  {}    \"{}\"".format(thread_id, thread_name))
+        print()
+
+def run_trace_configure(args):
+    factory = scalopus.transport.TransportUnixFactory()
+    poller = scalopus.general.EndpointManagerPoll(factory)
+    poller.addEndpointFactory(scalopus.tracing.EndpointTraceConfigurator.name,
+                              scalopus.tracing.EndpointTraceConfigurator.factory)
+    poller.addEndpointFactory(scalopus.general.EndpointProcessInfo.name,
+                              scalopus.general.EndpointProcessInfo.factory)
+    # Perform just one discovery round
+    poller.manage()
+
+    # perform manipulations as requested.
+    relevant_ids = set(args.id)
+    new_trace_state = args.state == "on"
+    new_unmatched_trace_state = args.unmatched_pid == "on"
+
+    # Retrieve active endpoints
+    endpoints = poller.endpoints()
+    entries = []
+    for transport, endpoint_map in endpoints.items():
+        if not scalopus.tracing.EndpointTraceConfigurator.name in endpoint_map:
+            continue
+
+        data = {}
+        pinfo = endpoint_map[scalopus.general.EndpointProcessInfo.name].processInfo()
+        data["pid"] = pinfo.pid
+        data["process_info"] = pinfo.to_dict()
+
+        new_state = scalopus.tracing.EndpointTraceConfigurator.TraceConfiguration()
+
+        if (pinfo.pid in relevant_ids):
+            new_state.set_process_state = True
+            new_state.process_state = new_trace_state
+        else:
+            if args.unmatched_pid:
+                new_state.set_process_state = True
+                new_state.process_state = new_unmatched_trace_state
+
+        for thread_id in pinfo.threads.keys():
+            if thread_id in relevant_ids:
+                new_state.add_thread_entry(thread_id, new_trace_state)
+
+        state = endpoint_map[scalopus.tracing.EndpointTraceConfigurator.name].setTraceState(new_state)
+        if not state.cmd_success:
+            print("Failed to retrieve state for transport: {}".format(transport.getAddress()))
+            continue
+        data["state"] = state.to_dict()
+
+        entries.append((data["pid"], data))
+    entries.sort()
+
+    def color_by_state(str, enabled):
+        if enabled:
+            return '\033[92m' + str + '\033[0m'
+        else:
+            return '\033[94m' + str + '\033[0m'
+
+    for pid, data in entries:
+        pid_str = color_by_state("{: >6d}".format(pid), data["state"]["process_state"])
+        print("PID: {}  \"{}\"".format(pid_str, data["process_info"]["name"]))
+        doffset = " " * 8
+        threads = data["process_info"]["threads"]
+        for thread_id, thread_name in sorted(threads.items()):
+            thread_idstr  = str(thread_id)
+            if thread_id in data["state"]["thread_state"]:
+                thread_idstr = color_by_state(thread_idstr, data["state"]["thread_state"][thread_id])
+            print(doffset + "  {}    \"{}\"".format(thread_idstr, thread_name))
+        print()
+
+        
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -102,12 +211,30 @@ if __name__ == "__main__":
         dest="catapult_log", default=True, action="store_false",
         help="Disable log output for the catapult server.")
 
-    if tracing.have_lttng:
+    if scalopus.tracing.have_lttng:
         parser_catapult_server.add_argument("--lttng-session", type=str,
         default="scalopus_target_session",
         help="The lttng session name to connect to, defaults to %(default)s.")
 
     parser_catapult_server.set_defaults(func=run_catapult_server)
+
+
+    discover_parser = subparsers.add_parser("discover", help="Discover "
+                                            "processes and show short info"
+                                            " about them.")
+    discover_parser.set_defaults(func=run_discover)
+
+    trace_configure_parser = subparsers.add_parser("trace_configure",
+        help="Configure the trace state.")
+    trace_configure_parser.add_argument('state', choices=['on', 'off'],
+        default=None, nargs="?", help="Matched id's will be set to this state.")
+    trace_configure_parser.add_argument('-u','--unmatched-pid',default=None,
+        choices=['on', 'off'], nargs="?",
+        help="Set unmatched process id's state to this value.")
+    trace_configure_parser.add_argument("id", nargs="*", type=int,
+        help="Process or thread ID to change.")
+    
+    trace_configure_parser.set_defaults(func=run_trace_configure)
 
     args = parser.parse_args()
 

--- a/scalopus_python/scalopus/tracing.py
+++ b/scalopus_python/scalopus/tracing.py
@@ -40,6 +40,7 @@ getProcessState = tracing.getProcessState
 setProcessState = tracing.setProcessState
 MarkLevel = tracing.MarkLevel
 EndpointTraceMapping = tracing.EndpointTraceMapping
+EndpointTraceConfigurator = tracing.EndpointTraceConfigurator
 EndpointNativeTraceSender = tracing.native.EndpointNativeTraceSender
 NativeTraceProvider = tracing.native.NativeTraceProvider
 

--- a/scalopus_tracing/CMakeLists.txt
+++ b/scalopus_tracing/CMakeLists.txt
@@ -4,6 +4,7 @@ include(FindThreads)
 
 add_library(scalopus_scope_tracing SHARED
   src/static_string_tracker.cpp
+  src/endpoint_trace_configurator.cpp
   src/endpoint_trace_mapping.cpp
   src/trace_configurator.cpp
   src/trace_configuration_raii.cpp

--- a/scalopus_tracing/include/scalopus_tracing/endpoint_trace_configurator.h
+++ b/scalopus_tracing/include/scalopus_tracing/endpoint_trace_configurator.h
@@ -1,0 +1,89 @@
+/*
+  Copyright (c) 2018-2019, Ivor Wanders
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+  * Neither the name of the author nor the names of contributors may be used to
+    endorse or promote products derived from this software without specific
+    prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#ifndef SCALOPUS_TRACING_ENDPOINT_TRACE_CONFIGURATOR_H
+#define SCALOPUS_TRACING_ENDPOINT_TRACE_CONFIGURATOR_H
+
+#include <scalopus_interface/transport.h>
+#include <map>
+#include <string>
+
+namespace scalopus
+{
+/**
+ * @brief This endpoint provides the thread names and process name.
+ */
+class EndpointTraceConfigurator : public Endpoint
+{
+public:
+  using Ptr = std::shared_ptr<EndpointTraceConfigurator>;
+  static const char* name;
+
+  struct TraceConfiguration
+  {
+    bool process_state{ false };                 //!< Are traces for this process enabled?
+    bool set_process_state{ false };             //!< Are we setting the process state?
+    std::map<unsigned long, bool> thread_state;  //!< Thread state, true = tracing enabled.
+    bool cmd_success{ false };
+
+    operator bool() const
+    {
+      return cmd_success;
+    }
+  };
+
+  /**
+   * @brief Constructor for this endpoint.
+   */
+  EndpointTraceConfigurator() = default;
+
+  //  ------   Client ------
+  /**
+   * @brief Set trace state, only modifies threads which are present in the map.
+   */
+  TraceConfiguration setTraceState(const TraceConfiguration& state) const;
+
+  /**
+   * @brief Get the current trace state.
+   */
+  TraceConfiguration getTraceState() const;
+
+  /**
+   * @brief Function to create a new instance of this class and assign the transport to it.
+   */
+  static Ptr factory(const Transport::Ptr& transport);
+
+  // From the endpoint
+  std::string getName() const;
+  bool handle(Transport& server, const Data& request, Data& response);
+};
+
+}  // namespace scalopus
+
+#endif  // SCALOPUS_TRACING_ENDPOINT_TRACE_CONFIGURATOR_H

--- a/scalopus_tracing/include/scalopus_tracing/endpoint_trace_mapping.h
+++ b/scalopus_tracing/include/scalopus_tracing/endpoint_trace_mapping.h
@@ -32,6 +32,7 @@
 
 #include <scalopus_interface/transport.h>
 #include <map>
+#include <unordered_map>
 #include <string>
 
 namespace scalopus
@@ -44,7 +45,7 @@ class EndpointTraceMapping : public Endpoint
 public:
   using Ptr = std::shared_ptr<EndpointTraceMapping>;
   static const char* name;  // "scope_tracing" defined in object file.
-  using TraceIdMap = std::map<unsigned int /* trace_id */, std::string /* name */>;
+  using TraceIdMap = std::unordered_map<unsigned int /* trace_id */, std::string /* name */>;
   using ProcessTraceMap = std::map<int /* pid */, TraceIdMap /* trace_map */>;
 
   /**

--- a/scalopus_tracing/include/scalopus_tracing/trace_configurator.h
+++ b/scalopus_tracing/include/scalopus_tracing/trace_configurator.h
@@ -47,7 +47,7 @@ private:
   TraceConfigurator(const TraceConfigurator&) = delete;
   TraceConfigurator& operator=(const TraceConfigurator&) = delete;
   TraceConfigurator& operator=(TraceConfigurator&&) = delete;
-
+  TraceConfigurator(const TraceConfigurator&&) = delete;
 
 public:
   using Ptr = std::shared_ptr<TraceConfigurator>;

--- a/scalopus_tracing/include/scalopus_tracing/trace_configurator.h
+++ b/scalopus_tracing/include/scalopus_tracing/trace_configurator.h
@@ -44,14 +44,22 @@ class TraceConfigurator
 {
 private:
   TraceConfigurator();
+  TraceConfigurator(const TraceConfigurator&) = delete;
+  TraceConfigurator& operator=(const TraceConfigurator&) = delete;
+  TraceConfigurator& operator=(TraceConfigurator&&) = delete;
+
 
 public:
+  using Ptr = std::shared_ptr<TraceConfigurator>;
+  using WeakPtr = std::weak_ptr<TraceConfigurator>;
   using AtomicBoolPtr = std::shared_ptr<std::atomic_bool>;
+
+  virtual ~TraceConfigurator() = default;
   /**
    * @brief Static method through which the singleton instance can be retrieved.
    * @return Returns the singleton instance of the ScopeConfigurator object.
    */
-  static TraceConfigurator& getInstance();
+  static TraceConfigurator::Ptr getInstance();
 
   /**
    * @brief Retrieve the atomic boolean for the thread requesting it.

--- a/scalopus_tracing/include/scalopus_tracing/tracing.h
+++ b/scalopus_tracing/include/scalopus_tracing/tracing.h
@@ -32,6 +32,7 @@
 
 #include <scalopus_general/general.h>
 #include <scalopus_tracing/endpoint_native_trace_sender.h>
+#include <scalopus_tracing/endpoint_trace_configurator.h>
 #include <scalopus_tracing/endpoint_trace_mapping.h>
 #include <scalopus_tracing/trace_configurator.h>
 #include <scalopus_tracing/trace_macro.h>

--- a/scalopus_tracing/src/endpoint_trace_configurator.cpp
+++ b/scalopus_tracing/src/endpoint_trace_configurator.cpp
@@ -1,0 +1,156 @@
+/*
+  Copyright (c) 2018-2019, Ivor Wanders
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+  * Neither the name of the author nor the names of contributors may be used to
+    endorse or promote products derived from this software without specific
+    prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include <scalopus_tracing/endpoint_trace_configurator.h>
+#include <scalopus_tracing/trace_configurator.h>
+#include <iostream>
+#include <nlohmann/json.hpp>
+
+namespace scalopus
+{
+using json = nlohmann::json;
+
+const char* EndpointTraceConfigurator::name = "trace_configurator";
+
+std::string EndpointTraceConfigurator::getName() const
+{
+  return name;
+}
+
+void to_json(json& j, const EndpointTraceConfigurator::TraceConfiguration& state)
+{
+  j["p"] = state.process_state;
+  j["sp"] = state.set_process_state;
+  j["t"] = state.thread_state;
+}
+
+void from_json(const json& j, EndpointTraceConfigurator::TraceConfiguration& state)
+{
+  j.at("p").get_to(state.process_state);
+  j.at("sp").get_to(state.set_process_state);
+  j.at("t").get_to(state.thread_state);
+}
+
+EndpointTraceConfigurator::TraceConfiguration
+EndpointTraceConfigurator::setTraceState(const TraceConfiguration& state) const
+{
+  // send message...
+  if (transport_ == nullptr)
+  {
+    throw communication_error("No transport provided to endpoint, cannot communicate.");
+  }
+
+  json request = json::object();
+  request["cmd"] = "set";
+  request["state"] = state;
+  auto future_ptr = transport_->request(getName(), json::to_bson(request));
+
+  if (future_ptr->wait_for(std::chrono::milliseconds(200)) == std::future_status::ready)
+  {
+    json jdata = json::from_bson(future_ptr->get());  // This line may throw
+    auto new_state = jdata.at("state").get<TraceConfiguration>();
+    new_state.cmd_success = true;
+    return new_state;
+  }
+  return {};
+}
+
+EndpointTraceConfigurator::TraceConfiguration EndpointTraceConfigurator::getTraceState() const
+{
+  // send message...
+  if (transport_ == nullptr)
+  {
+    throw communication_error("No transport provided to endpoint, cannot communicate.");
+  }
+
+  json request = json::object();
+  request["cmd"] = "get";
+  auto future_ptr = transport_->request(getName(), json::to_bson(request));
+
+  if (future_ptr->wait_for(std::chrono::milliseconds(200)) == std::future_status::ready)
+  {
+    json jdata = json::from_bson(future_ptr->get());  // This line may throw
+    auto new_state = jdata.at("state").get<TraceConfiguration>();
+    new_state.cmd_success = true;
+    return new_state;
+  }
+  return {};
+}
+
+bool EndpointTraceConfigurator::handle(Transport& /* server */, const Data& request, Data& response)
+{
+  json req = json::from_bson(request);
+  auto configurator_instance = TraceConfigurator::getInstance();
+
+  auto thread_map = configurator_instance->getThreadMap();
+  auto process_state = configurator_instance->getProcessStatePtr();
+
+  if (req.at("cmd").get<std::string>() == "set")
+  {
+    const auto new_state = req.at("state").get<TraceConfiguration>();
+    // Store the new process state
+    if (new_state.set_process_state)
+    {
+      process_state->store(new_state.process_state);
+    }
+
+    // Iterate over the provided thread id's and try to set their state.
+    for (const auto& k_v : new_state.thread_state)
+    {
+      auto it = thread_map.find(k_v.first);
+      if (it != thread_map.end())
+      {
+        it->second->store(k_v.second);
+      }
+    }
+  }
+
+  // Now, create a response with the current state.
+  json jdata = json::object();
+  TraceConfiguration updated_state;
+
+  // Store the process state
+  updated_state.process_state = process_state->load();
+
+  // Store the thread state
+  std::for_each(thread_map.begin(), thread_map.end(),
+                [&](const auto& p) { updated_state.thread_state[p.first] = p.second->load(); });
+  jdata["state"] = updated_state;
+  response = json::to_bson(jdata);
+  return true;
+}
+
+EndpointTraceConfigurator::Ptr EndpointTraceConfigurator::factory(const Transport::Ptr& transport)
+{
+  auto endpoint = std::make_shared<EndpointTraceConfigurator>();
+  endpoint->setTransport(transport);
+  return endpoint;
+}
+
+}  // namespace scalopus

--- a/scalopus_tracing/src/lttng/lttng_tracepoint.cpp
+++ b/scalopus_tracing/src/lttng/lttng_tracepoint.cpp
@@ -40,10 +40,10 @@ namespace lttng
 {
 void scope_entry(const unsigned int id)
 {
-  thread_local auto configurator_ptr = TraceConfigurator::getInstance();
-  static auto& process_state = *(configurator_ptr->getProcessStatePtr());
-  thread_local auto& thread_state = *(configurator_ptr->getThreadStatePtr());
-  if (!(process_state.load() && thread_state.load()))
+  static auto configurator_ptr = TraceConfigurator::getInstance();
+  static auto process_state = configurator_ptr->getProcessStatePtr();
+  thread_local auto thread_state = configurator_ptr->getThreadStatePtr();
+  if (!(process_state->load() && thread_state->load()))
   {
     return;
   }
@@ -52,10 +52,10 @@ void scope_entry(const unsigned int id)
 
 void scope_exit(const unsigned int id)
 {
-  thread_local auto configurator_ptr = TraceConfigurator::getInstance();
-  static auto& process_state = *(configurator_ptr->getProcessStatePtr());
-  thread_local auto& thread_state = *(configurator_ptr->getThreadStatePtr());
-  if (!(process_state.load() && thread_state.load()))
+  static auto configurator_ptr = TraceConfigurator::getInstance();
+  static auto process_state = configurator_ptr->getProcessStatePtr();
+  thread_local auto thread_state = configurator_ptr->getThreadStatePtr();
+  if (!(process_state->load() && thread_state->load()))
   {
     return;
   }
@@ -64,10 +64,10 @@ void scope_exit(const unsigned int id)
 
 void mark_event(const unsigned int id, const MarkLevel mark_level)
 {
-  thread_local auto configurator_ptr = TraceConfigurator::getInstance();
-  static auto& process_state = *(configurator_ptr->getProcessStatePtr());
-  thread_local auto& thread_state = *(configurator_ptr->getThreadStatePtr());
-  if (!(process_state.load() && thread_state.load()))
+  static auto configurator_ptr = TraceConfigurator::getInstance();
+  static auto process_state = configurator_ptr->getProcessStatePtr();
+  thread_local auto thread_state = configurator_ptr->getThreadStatePtr();
+  if (!(process_state->load() && thread_state->load()))
   {
     return;
   }

--- a/scalopus_tracing/src/lttng/lttng_tracepoint.cpp
+++ b/scalopus_tracing/src/lttng/lttng_tracepoint.cpp
@@ -40,8 +40,9 @@ namespace lttng
 {
 void scope_entry(const unsigned int id)
 {
-  static auto& process_state = *(TraceConfigurator::getInstance().getProcessStatePtr());
-  static thread_local auto& thread_state = *(TraceConfigurator::getInstance().getThreadStatePtr());
+  thread_local auto configurator_ptr = TraceConfigurator::getInstance();
+  static auto& process_state = *(configurator_ptr->getProcessStatePtr());
+  thread_local auto& thread_state = *(configurator_ptr->getThreadStatePtr());
   if (!(process_state.load() && thread_state.load()))
   {
     return;
@@ -51,8 +52,9 @@ void scope_entry(const unsigned int id)
 
 void scope_exit(const unsigned int id)
 {
-  static auto& process_state = *(TraceConfigurator::getInstance().getProcessStatePtr());
-  static thread_local auto& thread_state = *(TraceConfigurator::getInstance().getThreadStatePtr());
+  thread_local auto configurator_ptr = TraceConfigurator::getInstance();
+  static auto& process_state = *(configurator_ptr->getProcessStatePtr());
+  thread_local auto& thread_state = *(configurator_ptr->getThreadStatePtr());
   if (!(process_state.load() && thread_state.load()))
   {
     return;
@@ -62,8 +64,9 @@ void scope_exit(const unsigned int id)
 
 void mark_event(const unsigned int id, const MarkLevel mark_level)
 {
-  static auto& process_state = *(TraceConfigurator::getInstance().getProcessStatePtr());
-  static thread_local auto& thread_state = *(TraceConfigurator::getInstance().getThreadStatePtr());
+  thread_local auto configurator_ptr = TraceConfigurator::getInstance();
+  static auto& process_state = *(configurator_ptr->getProcessStatePtr());
+  thread_local auto& thread_state = *(configurator_ptr->getThreadStatePtr());
   if (!(process_state.load() && thread_state.load()))
   {
     return;

--- a/scalopus_tracing/src/lttng/lttng_tracepoint.cpp
+++ b/scalopus_tracing/src/lttng/lttng_tracepoint.cpp
@@ -43,7 +43,7 @@ void scope_entry(const unsigned int id)
   static auto configurator_ptr = TraceConfigurator::getInstance();
   static auto process_state = configurator_ptr->getProcessStatePtr();
   thread_local auto thread_state = configurator_ptr->getThreadStatePtr();
-  if (!(process_state->load() && thread_state->load()))
+  if (!process_state->load() || !thread_state->load())
   {
     return;
   }
@@ -55,7 +55,7 @@ void scope_exit(const unsigned int id)
   static auto configurator_ptr = TraceConfigurator::getInstance();
   static auto process_state = configurator_ptr->getProcessStatePtr();
   thread_local auto thread_state = configurator_ptr->getThreadStatePtr();
-  if (!(process_state->load() && thread_state->load()))
+  if (!process_state->load() || !thread_state->load())
   {
     return;
   }
@@ -67,7 +67,7 @@ void mark_event(const unsigned int id, const MarkLevel mark_level)
   static auto configurator_ptr = TraceConfigurator::getInstance();
   static auto process_state = configurator_ptr->getProcessStatePtr();
   thread_local auto thread_state = configurator_ptr->getThreadStatePtr();
-  if (!(process_state->load() && thread_state->load()))
+  if (!process_state->load() || !thread_state->load())
   {
     return;
   }

--- a/scalopus_tracing/src/native/endpoint_native_trace_sender.cpp
+++ b/scalopus_tracing/src/native/endpoint_native_trace_sender.cpp
@@ -78,7 +78,8 @@ static Data process_events(const EventMap& tid_event_map)
 void EndpointNativeTraceSender::work()
 {
   // The collector is a singleton, just retrieve it once.
-  const auto& collector = TracePointCollectorNative::getInstance();
+  const auto collector_ptr = TracePointCollectorNative::getInstance();
+  const auto& collector = *collector_ptr;
   while (running_)
   {
     auto tid_buffers = collector.getMap();

--- a/scalopus_tracing/src/native/native_tracepoint.cpp
+++ b/scalopus_tracing/src/native/native_tracepoint.cpp
@@ -59,41 +59,44 @@ static int64_t nativeGetChrono()
 
 void scope_entry(const unsigned int id)
 {
-  thread_local auto configurator_ptr = TraceConfigurator::getInstance();
-  thread_local auto& buffer = *(TracePointCollectorNative::getInstance().getBuffer());
-  static auto& process_state = *(configurator_ptr->getProcessStatePtr());
-  thread_local auto& thread_state = *(configurator_ptr->getThreadStatePtr());
-  if (!(process_state.load() && thread_state.load()))
+  static auto configurator_ptr = TraceConfigurator::getInstance();
+  thread_local auto buffer_ptr = TracePointCollectorNative::getInstance();
+  thread_local auto buffer = buffer_ptr->getBuffer();
+  static auto process_state = configurator_ptr->getProcessStatePtr();
+  thread_local auto thread_state = configurator_ptr->getThreadStatePtr();
+  if (!(process_state->load() && thread_state->load()))
   {
     return;
   }
   // @TODO Do something with overrun, count lost events?
-  buffer.push(
+  buffer->push(
       tracepoint_collector_types::StaticTraceEvent{ nativeGetChrono(), id, TracePointCollectorNative::SCOPE_ENTRY });
 }
 
 void scope_exit(const unsigned int id)
 {
-  thread_local auto configurator_ptr = TraceConfigurator::getInstance();
-  thread_local auto& buffer = *(TracePointCollectorNative::getInstance().getBuffer());
-  static auto& process_state = *(configurator_ptr->getProcessStatePtr());
-  thread_local auto& thread_state = *(configurator_ptr->getThreadStatePtr());
-  if (!(process_state.load() && thread_state.load()))
+  static auto configurator_ptr = TraceConfigurator::getInstance();
+  thread_local auto buffer_ptr = TracePointCollectorNative::getInstance();
+  thread_local auto buffer = buffer_ptr->getBuffer();
+  static auto process_state = configurator_ptr->getProcessStatePtr();
+  thread_local auto thread_state = configurator_ptr->getThreadStatePtr();
+  if (!(process_state->load() && thread_state->load()))
   {
     return;
   }
   // @TODO Do something with overrun, count lost events?
-  buffer.push(
+  buffer->push(
       tracepoint_collector_types::StaticTraceEvent{ nativeGetChrono(), id, TracePointCollectorNative::SCOPE_EXIT });
 }
 
 void mark_event(const unsigned int id, const MarkLevel mark_level)
 {
-  thread_local auto configurator_ptr = TraceConfigurator::getInstance();
-  thread_local auto& buffer = *(TracePointCollectorNative::getInstance().getBuffer());
-  static auto& process_state = *(configurator_ptr->getProcessStatePtr());
-  thread_local auto& thread_state = *(configurator_ptr->getThreadStatePtr());
-  if (!(process_state.load() && thread_state.load()))
+  static auto configurator_ptr = TraceConfigurator::getInstance();
+  thread_local auto buffer_ptr = TracePointCollectorNative::getInstance();
+  thread_local auto buffer = buffer_ptr->getBuffer();
+  static auto process_state = configurator_ptr->getProcessStatePtr();
+  thread_local auto thread_state = configurator_ptr->getThreadStatePtr();
+  if (!(process_state->load() && thread_state->load()))
   {
     return;
   }
@@ -101,15 +104,15 @@ void mark_event(const unsigned int id, const MarkLevel mark_level)
   switch (mark_level)
   {
     case MarkLevel::GLOBAL:
-      buffer.push(tracepoint_collector_types::StaticTraceEvent{ nativeGetChrono(), id,
+      buffer->push(tracepoint_collector_types::StaticTraceEvent{ nativeGetChrono(), id,
                                                                 TracePointCollectorNative::MARK_GLOBAL });
       break;
     case MarkLevel::PROCESS:
-      buffer.push(tracepoint_collector_types::StaticTraceEvent{ nativeGetChrono(), id,
+      buffer->push(tracepoint_collector_types::StaticTraceEvent{ nativeGetChrono(), id,
                                                                 TracePointCollectorNative::MARK_PROCESS });
       break;
     case MarkLevel::THREAD:
-      buffer.push(tracepoint_collector_types::StaticTraceEvent{ nativeGetChrono(), id,
+      buffer->push(tracepoint_collector_types::StaticTraceEvent{ nativeGetChrono(), id,
                                                                 TracePointCollectorNative::MARK_THREAD });
       break;
   }

--- a/scalopus_tracing/src/native/native_tracepoint.cpp
+++ b/scalopus_tracing/src/native/native_tracepoint.cpp
@@ -64,7 +64,7 @@ void scope_entry(const unsigned int id)
   thread_local auto buffer = buffer_ptr->getBuffer();
   static auto process_state = configurator_ptr->getProcessStatePtr();
   thread_local auto thread_state = configurator_ptr->getThreadStatePtr();
-  if (!(process_state->load() && thread_state->load()))
+  if (!process_state->load() || !thread_state->load())
   {
     return;
   }
@@ -80,7 +80,7 @@ void scope_exit(const unsigned int id)
   thread_local auto buffer = buffer_ptr->getBuffer();
   static auto process_state = configurator_ptr->getProcessStatePtr();
   thread_local auto thread_state = configurator_ptr->getThreadStatePtr();
-  if (!(process_state->load() && thread_state->load()))
+  if (!process_state->load() || !thread_state->load())
   {
     return;
   }
@@ -96,7 +96,7 @@ void mark_event(const unsigned int id, const MarkLevel mark_level)
   thread_local auto buffer = buffer_ptr->getBuffer();
   static auto process_state = configurator_ptr->getProcessStatePtr();
   thread_local auto thread_state = configurator_ptr->getThreadStatePtr();
-  if (!(process_state->load() && thread_state->load()))
+  if (!process_state->load() || !thread_state->load())
   {
     return;
   }
@@ -105,15 +105,15 @@ void mark_event(const unsigned int id, const MarkLevel mark_level)
   {
     case MarkLevel::GLOBAL:
       buffer->push(tracepoint_collector_types::StaticTraceEvent{ nativeGetChrono(), id,
-                                                                TracePointCollectorNative::MARK_GLOBAL });
+                                                                 TracePointCollectorNative::MARK_GLOBAL });
       break;
     case MarkLevel::PROCESS:
       buffer->push(tracepoint_collector_types::StaticTraceEvent{ nativeGetChrono(), id,
-                                                                TracePointCollectorNative::MARK_PROCESS });
+                                                                 TracePointCollectorNative::MARK_PROCESS });
       break;
     case MarkLevel::THREAD:
       buffer->push(tracepoint_collector_types::StaticTraceEvent{ nativeGetChrono(), id,
-                                                                TracePointCollectorNative::MARK_THREAD });
+                                                                 TracePointCollectorNative::MARK_THREAD });
       break;
   }
 }

--- a/scalopus_tracing/src/native/native_tracepoint.cpp
+++ b/scalopus_tracing/src/native/native_tracepoint.cpp
@@ -59,9 +59,10 @@ static int64_t nativeGetChrono()
 
 void scope_entry(const unsigned int id)
 {
-  static thread_local auto& buffer = *(TracePointCollectorNative::getInstance().getBuffer());
-  static auto& process_state = *(TraceConfigurator::getInstance().getProcessStatePtr());
-  static thread_local auto& thread_state = *(TraceConfigurator::getInstance().getThreadStatePtr());
+  thread_local auto configurator_ptr = TraceConfigurator::getInstance();
+  thread_local auto& buffer = *(TracePointCollectorNative::getInstance().getBuffer());
+  static auto& process_state = *(configurator_ptr->getProcessStatePtr());
+  thread_local auto& thread_state = *(configurator_ptr->getThreadStatePtr());
   if (!(process_state.load() && thread_state.load()))
   {
     return;
@@ -73,9 +74,10 @@ void scope_entry(const unsigned int id)
 
 void scope_exit(const unsigned int id)
 {
-  static thread_local auto& buffer = *(TracePointCollectorNative::getInstance().getBuffer());
-  static auto& process_state = *(TraceConfigurator::getInstance().getProcessStatePtr());
-  static thread_local auto& thread_state = *(TraceConfigurator::getInstance().getThreadStatePtr());
+  thread_local auto configurator_ptr = TraceConfigurator::getInstance();
+  thread_local auto& buffer = *(TracePointCollectorNative::getInstance().getBuffer());
+  static auto& process_state = *(configurator_ptr->getProcessStatePtr());
+  thread_local auto& thread_state = *(configurator_ptr->getThreadStatePtr());
   if (!(process_state.load() && thread_state.load()))
   {
     return;
@@ -87,9 +89,10 @@ void scope_exit(const unsigned int id)
 
 void mark_event(const unsigned int id, const MarkLevel mark_level)
 {
-  static thread_local auto& buffer = *(TracePointCollectorNative::getInstance().getBuffer());
-  static auto& process_state = *(TraceConfigurator::getInstance().getProcessStatePtr());
-  static thread_local auto& thread_state = *(TraceConfigurator::getInstance().getThreadStatePtr());
+  thread_local auto configurator_ptr = TraceConfigurator::getInstance();
+  thread_local auto& buffer = *(TracePointCollectorNative::getInstance().getBuffer());
+  static auto& process_state = *(configurator_ptr->getProcessStatePtr());
+  thread_local auto& thread_state = *(configurator_ptr->getThreadStatePtr());
   if (!(process_state.load() && thread_state.load()))
   {
     return;

--- a/scalopus_tracing/src/native/tracepoint_collector_native.cpp
+++ b/scalopus_tracing/src/native/tracepoint_collector_native.cpp
@@ -42,8 +42,10 @@ TracePointCollectorNative::Ptr TracePointCollectorNative::getInstance()
 {
   // https://stackoverflow.com/questions/8147027/
   // Trick to allow make_shared with a private constructor.
-  struct make_shared_enabler : public TracePointCollectorNative {};
-  static TracePointCollectorNative::Ptr instance{std::make_shared<make_shared_enabler>()};
+  struct make_shared_enabler : public TracePointCollectorNative
+  {
+  };
+  static TracePointCollectorNative::Ptr instance{ std::make_shared<make_shared_enabler>() };
   return instance;
 }
 
@@ -53,13 +55,12 @@ tracepoint_collector_types::ScopeBufferPtr TracePointCollectorNative::getBuffer(
   // Register a destructor callback such that the thread gets removed from the map when the thread exits.
   auto instance_pointer = getInstance();
   thread_local DestructorCallback cleanup{ [instance = TracePointCollectorNative::WeakPtr(instance_pointer), tid]() {
-      auto ptr = instance.lock();
-      if (ptr != nullptr)
-      {
-        ptr->erase(tid);
-      }
+    auto ptr = instance.lock();
+    if (ptr != nullptr)
+    {
+      ptr->erase(tid);
     }
-  };
+  } };
 
   if (exists(tid))
   {

--- a/scalopus_tracing/src/native/tracepoint_collector_native.cpp
+++ b/scalopus_tracing/src/native/tracepoint_collector_native.cpp
@@ -65,7 +65,7 @@ tracepoint_collector_types::ScopeBufferPtr TracePointCollectorNative::getBuffer(
   if (exists(tid))
   {
     // Buffer already existed for this thread.
-    return getKey(tid);
+    return getValue(tid);
   }
   else
   {

--- a/scalopus_tracing/src/native/tracepoint_collector_native.cpp
+++ b/scalopus_tracing/src/native/tracepoint_collector_native.cpp
@@ -65,7 +65,7 @@ tracepoint_collector_types::ScopeBufferPtr TracePointCollectorNative::getBuffer(
   if (exists(tid))
   {
     // Buffer already existed for this thread.
-    return getMap()[tid];
+    return getKey(tid);
   }
   else
   {

--- a/scalopus_tracing/src/native/tracepoint_collector_native.h
+++ b/scalopus_tracing/src/native/tracepoint_collector_native.h
@@ -59,6 +59,9 @@ class TracePointCollectorNative : public MapTracker<unsigned long, tracepoint_co
 {
 private:
   TracePointCollectorNative() = default;
+  TracePointCollectorNative(const TracePointCollectorNative&) = delete;
+  TracePointCollectorNative& operator=(const TracePointCollectorNative&) = delete;
+  TracePointCollectorNative& operator=(TracePointCollectorNative&&) = delete;
 
   /**
    * @brief The size of each thread's ringbuffer.
@@ -68,6 +71,9 @@ private:
   std::size_t ringbuffer_size_{ 10000 };
 
 public:
+  using Ptr = std::shared_ptr<TracePointCollectorNative>;
+  using WeakPtr = std::weak_ptr<TracePointCollectorNative>;
+
   static const uint8_t SCOPE_ENTRY;  // If initialised here and made constexpr clang drops it during linking :(
   static const uint8_t SCOPE_EXIT;
   static const uint8_t MARK_GLOBAL;
@@ -78,7 +84,7 @@ public:
    * @brief Static method through which the singleton instance can be retrieved.
    * @return Returns the singleton instance of the object.
    */
-  static TracePointCollectorNative& getInstance();
+  static TracePointCollectorNative::Ptr getInstance();
 
   /**
    * @brief Called by each thread to obtain the ringbuffer in which it should store the trace events.

--- a/scalopus_tracing/src/native/tracepoint_collector_native.h
+++ b/scalopus_tracing/src/native/tracepoint_collector_native.h
@@ -32,6 +32,7 @@
 
 #include <scalopus_general/map_tracker.h>
 #include <chrono>
+#include <map>
 #include <vector>
 #include "spsc_ringbuffer.h"
 namespace scalopus

--- a/scalopus_tracing/src/trace_configuration_raii.cpp
+++ b/scalopus_tracing/src/trace_configuration_raii.cpp
@@ -34,27 +34,27 @@ namespace scalopus
 {
 TraceConfigurationRAII::TraceConfigurationRAII(const bool is_process, const bool new_state) : is_process_(is_process)
 {
-  TraceConfigurator& configurator = TraceConfigurator::getInstance();
+  TraceConfigurator::Ptr configurator = TraceConfigurator::getInstance();
   if (is_process_)
   {
-    previous_state_ = configurator.setProcessState(new_state);
+    previous_state_ = configurator->setProcessState(new_state);
   }
   else
   {
-    previous_state_ = configurator.setThreadState(new_state);
+    previous_state_ = configurator->setThreadState(new_state);
   }
 }
 
 TraceConfigurationRAII::~TraceConfigurationRAII()
 {
-  TraceConfigurator& configurator = TraceConfigurator::getInstance();
+  TraceConfigurator::Ptr configurator = TraceConfigurator::getInstance();
   if (is_process_)
   {
-    configurator.setProcessState(previous_state_);
+    configurator->setProcessState(previous_state_);
   }
   else
   {
-    configurator.setThreadState(previous_state_);
+    configurator->setThreadState(previous_state_);
   }
 }
 

--- a/scalopus_tracing/src/trace_configurator.cpp
+++ b/scalopus_tracing/src/trace_configurator.cpp
@@ -44,13 +44,12 @@ TraceConfigurator::AtomicBoolPtr TraceConfigurator::getThreadStatePtr()
   //  Register a destructor callback such that the thread gets removed from the map when the thread exits.
   auto instance_pointer = getInstance();
   thread_local DestructorCallback cleanup{ [instance = TraceConfigurator::WeakPtr(instance_pointer), tid]() {
-      auto ptr = instance.lock();
-      if (ptr != nullptr)
-      {
-        ptr->removeThread(tid);
-      }
+    auto ptr = instance.lock();
+    if (ptr != nullptr)
+    {
+      ptr->removeThread(tid);
     }
-  };
+  } };
   std::lock_guard<decltype(threads_map_mutex_)> lock(threads_map_mutex_);
   auto it = thread_state_.find(tid);
   if (it != thread_state_.end())
@@ -106,8 +105,10 @@ TraceConfigurator::Ptr TraceConfigurator::getInstance()
 {
   // https://stackoverflow.com/questions/8147027/
   // Trick to allow make_shared with a private constructor.
-  struct make_shared_enabler : public TraceConfigurator {};
-  static TraceConfigurator::Ptr instance{std::make_shared<make_shared_enabler>()};
+  struct make_shared_enabler : public TraceConfigurator
+  {
+  };
+  static TraceConfigurator::Ptr instance{ std::make_shared<make_shared_enabler>() };
   return instance;
 }
 

--- a/scalopus_tracing/src/trace_configurator.cpp
+++ b/scalopus_tracing/src/trace_configurator.cpp
@@ -41,8 +41,16 @@ TraceConfigurator::AtomicBoolPtr TraceConfigurator::getThreadStatePtr()
 {
   auto tid = static_cast<unsigned long>(pthread_self());
 
-  // Register a destructor callback such that the thread gets removed from the map when the thread exits.
-  thread_local DestructorCallback cleanup{ [this, tid]() { removeThread(tid); } };
+  //  Register a destructor callback such that the thread gets removed from the map when the thread exits.
+  auto instance_pointer = getInstance();
+  thread_local DestructorCallback cleanup{ [instance = TraceConfigurator::WeakPtr(instance_pointer), tid]() {
+      auto ptr = instance.lock();
+      if (ptr != nullptr)
+      {
+        ptr->removeThread(tid);
+      }
+    }
+  };
   std::lock_guard<decltype(threads_map_mutex_)> lock(threads_map_mutex_);
   auto it = thread_state_.find(tid);
   if (it != thread_state_.end())
@@ -94,9 +102,12 @@ std::map<unsigned long, TraceConfigurator::AtomicBoolPtr> TraceConfigurator::get
   return thread_state_;
 }
 
-TraceConfigurator& TraceConfigurator::getInstance()
+TraceConfigurator::Ptr TraceConfigurator::getInstance()
 {
-  static TraceConfigurator instance;
+  // https://stackoverflow.com/questions/8147027/
+  // Trick to allow make_shared with a private constructor.
+  struct make_shared_enabler : public TraceConfigurator {};
+  static TraceConfigurator::Ptr instance{std::make_shared<make_shared_enabler>()};
   return instance;
 }
 

--- a/scalopus_tracing/test/test_native_tracepoints.cpp
+++ b/scalopus_tracing/test/test_native_tracepoints.cpp
@@ -123,7 +123,7 @@ int main(int /* argc */, char** /* argv */)
   test_less(std::abs(expected - difference), allow_difference);
 
   // Disable this threads' tracepoints
-  scalopus::TraceConfigurator::getInstance().setThreadState(false);
+  scalopus::TraceConfigurator::getInstance()->setThreadState(false);
   source->startInterval();
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   // From another thread emit a tracepoint.
@@ -145,7 +145,7 @@ int main(int /* argc */, char** /* argv */)
   test(result[1]["name"], "different_thread");
 
   // Enable the tracepoints again.
-  scalopus::TraceConfigurator::getInstance().setThreadState(true);
+  scalopus::TraceConfigurator::getInstance()->setThreadState(true);
   source->startInterval();
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   {
@@ -158,7 +158,7 @@ int main(int /* argc */, char** /* argv */)
   test(result[1]["name"], "enabled");
 
   // Disable process state.
-  scalopus::TraceConfigurator::getInstance().setProcessState(false);
+  scalopus::TraceConfigurator::getInstance()->setProcessState(false);
   source->startInterval();
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   {
@@ -169,7 +169,7 @@ int main(int /* argc */, char** /* argv */)
   test(result.size(), 0u);  // Expect no tracepoints.
 
   // Finally check whether we can flip the process state back to true.
-  scalopus::TraceConfigurator::getInstance().setProcessState(true);
+  scalopus::TraceConfigurator::getInstance()->setProcessState(true);
   source->startInterval();
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   {

--- a/scalopus_transport/src/transport_unix.cpp
+++ b/scalopus_transport/src/transport_unix.cpp
@@ -115,6 +115,7 @@ bool TransportUnix::connect(std::size_t pid)
   std::stringstream ss;
   ss << "" << pid << "_scalopus";
   std::strncpy(socket_config.sun_path + 1, ss.str().c_str(), sizeof(socket_config.sun_path) - 2);
+  client_pid_ = pid;
 
   std::size_t path_length = sizeof(socket_config.sun_family) + strlen(socket_config.sun_path + 1) + 1;
   if (::connect(client_fd_, reinterpret_cast<sockaddr*>(&socket_config), static_cast<unsigned int>(path_length)) == -1)
@@ -406,7 +407,14 @@ bool TransportUnix::processMsg(const protocol::Msg& request, protocol::Msg& resp
 
 Destination::Ptr TransportUnix::getAddress()
 {
-  return std::make_shared<DestinationUnix>(::getpid());
+  if (server_fd_ != 0)
+  {
+    return std::make_shared<DestinationUnix>(::getpid());
+  }
+  else
+  {
+    return std::make_shared<DestinationUnix>(client_pid_);
+  }
 }
 
 // Methods for the factory

--- a/scalopus_transport/src/transport_unix.h
+++ b/scalopus_transport/src/transport_unix.h
@@ -87,6 +87,7 @@ private:
   void work();          //!< Function for the worker thread.
   int server_fd_{ 0 };  //!< File descriptor from the server bind.
   int client_fd_{ 0 };  //!< File descriptor from connecting to a server.
+  std::size_t client_pid_{ 0 };
 
   bool running_{ false };  //!< Boolean to quit the worker thread.
 


### PR DESCRIPTION
We saw stacktraces where on shutdown we were still trying to interact with the Configurator. Somehow the `static TraceConfigurator` that made the singleton went out of scope before all threads died, causing write into freed memory.

I still don't really know how that could've happened, I was not able to recreate it in a simple test case. Regardless, I think we can prevent it by storing the singleton in a shared pointer and making sure all threads have a copy of the shared pointer. That way if a process doesn't close threads correctly and shuts down before all threads join we still shouldn't end up writing into freed memory.