### PR TITLE
Support toggling processes and threads through CLI

### DIFF
--- a/scalopus_catapult/src/scalopus_catapult_server.cpp
+++ b/scalopus_catapult/src/scalopus_catapult_server.cpp
@@ -30,6 +30,7 @@
 
 #include <scalopus_general/general_provider.h>
 #include <scalopus_tracing/endpoint_native_trace_sender.h>
+#include <scalopus_tracing/endpoint_trace_configurator.h>
 #include <scalopus_tracing/lttng_provider.h>
 #include <scalopus_tracing/native_trace_provider.h>
 #include <scalopus_transport/transport_unix.h>
@@ -99,6 +100,11 @@ int main(int argc, char** argv)
 
   // Add endpoint factory function for the process information.
   manager->addEndpointFactory<scalopus::EndpointProcessInfo>();
+
+  // Adding this endpoint, just to prevent it from complaining for now.
+  // In the future we could use this endpoint to toggle threads from the UI, but the UI's support for this is quite
+  // poor, and once a setting is seen it will be present indefinitely.
+  manager->addEndpointFactory<scalopus::EndpointTraceConfigurator>();
 
   auto native_trace_provider = std::make_shared<scalopus::NativeTraceProvider>(manager);
   manager->addEndpointFactory(scalopus::EndpointNativeTraceSender::name, native_trace_provider);

--- a/scalopus_examples/src/query_servers.cpp
+++ b/scalopus_examples/src/query_servers.cpp
@@ -94,8 +94,8 @@ int main(int /* argc */, char** /* argv */)
         client->setTransport(transport);
         const auto state = client->getTraceState();
         server_info[scalopus::EndpointTraceConfigurator::name] = { { "process_state", state.process_state },
-                                                             { "thread_state", state.thread_state },
-                                                             { "cmd_success", state.cmd_success } };
+                                                                   { "thread_state", state.thread_state },
+                                                                   { "cmd_success", state.cmd_success } };
         std::cerr << "  process_state:     " << state.process_state << std::endl;
         continue;
       }

--- a/scalopus_examples/src/query_servers.cpp
+++ b/scalopus_examples/src/query_servers.cpp
@@ -88,6 +88,18 @@ int main(int /* argc */, char** /* argv */)
         continue;
       }
 
+      if (name == scalopus::EndpointTraceConfigurator::name)
+      {
+        auto client = std::make_shared<scalopus::EndpointTraceConfigurator>();
+        client->setTransport(transport);
+        const auto state = client->getTraceState();
+        server_info[scalopus::EndpointTraceConfigurator::name] = { { "process_state", state.process_state },
+                                                             { "thread_state", state.thread_state },
+                                                             { "cmd_success", state.cmd_success } };
+        std::cerr << "  process_state:     " << state.process_state << std::endl;
+        continue;
+      }
+
       if (name == scalopus::EndpointTraceMapping::name)
       {
         auto client = std::make_shared<scalopus::EndpointTraceMapping>();

--- a/scalopus_examples/src/random_callstacks.cpp
+++ b/scalopus_examples/src/random_callstacks.cpp
@@ -119,6 +119,7 @@ int main(int argc, char** argv)
   const auto server = factory->serve();
   server->addEndpoint(std::make_unique<scalopus::EndpointTraceMapping>());
   server->addEndpoint(std::make_unique<scalopus::EndpointIntrospect>());
+  server->addEndpoint(std::make_unique<scalopus::EndpointTraceConfigurator>());
   auto endpoint_process_info = std::make_shared<scalopus::EndpointProcessInfo>();
   endpoint_process_info->setProcessName(argv[0]);
   server->addEndpoint(endpoint_process_info);

--- a/scalopus_python/lib/scalopus_general.cpp
+++ b/scalopus_python/lib/scalopus_general.cpp
@@ -50,7 +50,15 @@ void add_scalopus_general(py::module& m)
 
   py::class_<EndpointProcessInfo::ProcessInfo> endpoint_process_info_info(general, "ProcessInfo");
   endpoint_process_info_info.def_readwrite("name", &EndpointProcessInfo::ProcessInfo::name);
+  endpoint_process_info_info.def_readwrite("pid", &EndpointProcessInfo::ProcessInfo::pid);
   endpoint_process_info_info.def_readwrite("threads", &EndpointProcessInfo::ProcessInfo::threads);
+  endpoint_process_info_info.def("to_dict", [](const EndpointProcessInfo::ProcessInfo& p){
+    auto dict = py::dict();
+    dict["name"] = p.name;
+    dict["threads"] = p.threads;
+    dict["pid"] = p.pid;
+    return dict;
+  });
 
   py::class_<EndpointProcessInfo, EndpointProcessInfo::Ptr, Endpoint> endpoint_process_info(general,
                                                                                             "EndpointProcessInfo");
@@ -70,6 +78,7 @@ void add_scalopus_general(py::module& m)
   endpoint_manager_poll.def("stopPolling", &EndpointManagerPoll::stopPolling);
   endpoint_manager_poll.def("manage", &EndpointManagerPoll::manage);
   endpoint_manager_poll.def("setLogger", &EndpointManagerPoll::setLogger);
+  endpoint_manager_poll.def("endpoints", &EndpointManagerPoll::endpoints);
 
   // General provider.
   py::class_<GeneralProvider, GeneralProvider::Ptr, TraceEventProvider> general_provider(general, "GeneralProvider");

--- a/scalopus_python/lib/scalopus_general.cpp
+++ b/scalopus_python/lib/scalopus_general.cpp
@@ -52,7 +52,7 @@ void add_scalopus_general(py::module& m)
   endpoint_process_info_info.def_readwrite("name", &EndpointProcessInfo::ProcessInfo::name);
   endpoint_process_info_info.def_readwrite("pid", &EndpointProcessInfo::ProcessInfo::pid);
   endpoint_process_info_info.def_readwrite("threads", &EndpointProcessInfo::ProcessInfo::threads);
-  endpoint_process_info_info.def("to_dict", [](const EndpointProcessInfo::ProcessInfo& p){
+  endpoint_process_info_info.def("to_dict", [](const EndpointProcessInfo::ProcessInfo& p) {
     auto dict = py::dict();
     dict["name"] = p.name;
     dict["threads"] = p.threads;

--- a/scalopus_python/lib/scalopus_interface.cpp
+++ b/scalopus_python/lib/scalopus_interface.cpp
@@ -181,6 +181,7 @@ void add_scalopus_interface(py::module& m)
   py::class_<Transport, Transport::Ptr> transport_interface(interface, "Transport");
   transport_interface.def("addEndpoint", &Transport::addEndpoint, py::keep_alive<1, 2>());
   transport_interface.def("isConnected", &Transport::isConnected);
+  transport_interface.def("getAddress", &Transport::getAddress);
   transport_interface.def("broadcast", &Transport::broadcast);
   transport_interface.def("request", [](Transport& transport, const std::string& name, const py::object& outgoing) {
     return std::make_shared<PendingResponse>(transport.request(name, pyToData(outgoing)));

--- a/scalopus_python/lib/scalopus_tracing.cpp
+++ b/scalopus_python/lib/scalopus_tracing.cpp
@@ -75,9 +75,6 @@ void add_scalopus_tracing(py::module& m)
 
   // Start EndpointTraceConfigurator
 
-  py::class_<EndpointTraceConfigurator::TraceConfiguration> endpoint_tc_trace_conf(tracing, "TraceConfiguration");
-  endpoint_tc_trace_conf.def_readwrite("process_state", &EndpointTraceConfigurator::TraceConfiguration::process_state);
-  endpoint_tc_trace_conf.def_readwrite("thread_state", &EndpointTraceConfigurator::TraceConfiguration::thread_state);
 
   py::class_<EndpointTraceConfigurator, EndpointTraceConfigurator::Ptr, Endpoint> endpoint_tc(tracing,
                                                                                             "EndpointTraceConfigurator");
@@ -86,6 +83,27 @@ void add_scalopus_tracing(py::module& m)
   endpoint_tc.def("getTraceState", &EndpointTraceConfigurator::getTraceState);
   endpoint_tc.def_property_readonly_static("name", [](py::object /* self */) { return EndpointTraceConfigurator::name; });
   endpoint_tc.def_static("factory", &EndpointTraceConfigurator::factory);
+
+  py::class_<EndpointTraceConfigurator::TraceConfiguration> endpoint_tc_trace_conf(endpoint_tc, "TraceConfiguration");
+  endpoint_tc_trace_conf.def(py::init<>());
+  endpoint_tc_trace_conf.def_readwrite("process_state", &EndpointTraceConfigurator::TraceConfiguration::process_state);
+  endpoint_tc_trace_conf.def_readwrite("cmd_success", &EndpointTraceConfigurator::TraceConfiguration::cmd_success);
+  endpoint_tc_trace_conf.def_readwrite("set_process_state", &EndpointTraceConfigurator::TraceConfiguration::set_process_state);
+  endpoint_tc_trace_conf.def_readwrite("thread_state", &EndpointTraceConfigurator::TraceConfiguration::thread_state);
+  // For some reason, assigning into tread_state directly didn't work, make a simple assign function.
+  endpoint_tc_trace_conf.def("add_thread_entry", [](EndpointTraceConfigurator::TraceConfiguration& v, unsigned long id, bool state)
+  {
+    v.thread_state[id] = state;
+  });
+
+  endpoint_tc_trace_conf.def("to_dict", [](const EndpointTraceConfigurator::TraceConfiguration& p){
+    auto dict = py::dict();
+    dict["set_process_state"] = p.set_process_state;
+    dict["process_state"] = p.process_state;
+    dict["cmd_success"] = p.cmd_success;
+    dict["thread_state"] = p.thread_state;
+    return dict;
+  });
   // End EndpointTraceConfigurator
 
 

--- a/scalopus_python/lib/scalopus_tracing.cpp
+++ b/scalopus_python/lib/scalopus_tracing.cpp
@@ -62,6 +62,7 @@ void add_scalopus_tracing(py::module& m)
       .value("PROCESS", MarkLevel::PROCESS)
       .value("THREAD", MarkLevel::THREAD);
 
+  // Start EndpointTraceMapping
   py::class_<EndpointTraceMapping, EndpointTraceMapping::Ptr, Endpoint> endpoint_trace_mapping(tracing,
                                                                                                "EndpointTraceMapping");
   endpoint_trace_mapping.def(py::init<>());
@@ -69,6 +70,24 @@ void add_scalopus_tracing(py::module& m)
   endpoint_trace_mapping.def_static("factory", &EndpointTraceMapping::factory);
   endpoint_trace_mapping.def_property_readonly_static("name",
                                                       [](py::object /* self */) { return EndpointTraceMapping::name; });
+  // End EndpointTraceMapping
+
+
+  // Start EndpointTraceConfigurator
+
+  py::class_<EndpointTraceConfigurator::TraceConfiguration> endpoint_tc_trace_conf(tracing, "TraceConfiguration");
+  endpoint_tc_trace_conf.def_readwrite("process_state", &EndpointTraceConfigurator::TraceConfiguration::process_state);
+  endpoint_tc_trace_conf.def_readwrite("thread_state", &EndpointTraceConfigurator::TraceConfiguration::thread_state);
+
+  py::class_<EndpointTraceConfigurator, EndpointTraceConfigurator::Ptr, Endpoint> endpoint_tc(tracing,
+                                                                                            "EndpointTraceConfigurator");
+  endpoint_tc.def(py::init<>());
+  endpoint_tc.def("setTraceState", &EndpointTraceConfigurator::setTraceState);
+  endpoint_tc.def("getTraceState", &EndpointTraceConfigurator::getTraceState);
+  endpoint_tc.def_property_readonly_static("name", [](py::object /* self */) { return EndpointTraceConfigurator::name; });
+  endpoint_tc.def_static("factory", &EndpointTraceConfigurator::factory);
+  // End EndpointTraceConfigurator
+
 
   py::module native = tracing.def_submodule("native", "The native specific components.");
   py::class_<EndpointNativeTraceSender, EndpointNativeTraceSender::Ptr, Endpoint> endpoint_native_trace_sender(

--- a/scalopus_python/lib/scalopus_tracing.cpp
+++ b/scalopus_python/lib/scalopus_tracing.cpp
@@ -72,31 +72,29 @@ void add_scalopus_tracing(py::module& m)
                                                       [](py::object /* self */) { return EndpointTraceMapping::name; });
   // End EndpointTraceMapping
 
-
   // Start EndpointTraceConfigurator
 
-
-  py::class_<EndpointTraceConfigurator, EndpointTraceConfigurator::Ptr, Endpoint> endpoint_tc(tracing,
-                                                                                            "EndpointTraceConfigurator");
+  py::class_<EndpointTraceConfigurator, EndpointTraceConfigurator::Ptr, Endpoint> endpoint_tc(
+      tracing, "EndpointTraceConfigurator");
   endpoint_tc.def(py::init<>());
   endpoint_tc.def("setTraceState", &EndpointTraceConfigurator::setTraceState);
   endpoint_tc.def("getTraceState", &EndpointTraceConfigurator::getTraceState);
-  endpoint_tc.def_property_readonly_static("name", [](py::object /* self */) { return EndpointTraceConfigurator::name; });
+  endpoint_tc.def_property_readonly_static("name",
+                                           [](py::object /* self */) { return EndpointTraceConfigurator::name; });
   endpoint_tc.def_static("factory", &EndpointTraceConfigurator::factory);
 
   py::class_<EndpointTraceConfigurator::TraceConfiguration> endpoint_tc_trace_conf(endpoint_tc, "TraceConfiguration");
   endpoint_tc_trace_conf.def(py::init<>());
   endpoint_tc_trace_conf.def_readwrite("process_state", &EndpointTraceConfigurator::TraceConfiguration::process_state);
   endpoint_tc_trace_conf.def_readwrite("cmd_success", &EndpointTraceConfigurator::TraceConfiguration::cmd_success);
-  endpoint_tc_trace_conf.def_readwrite("set_process_state", &EndpointTraceConfigurator::TraceConfiguration::set_process_state);
+  endpoint_tc_trace_conf.def_readwrite("set_process_state",
+                                       &EndpointTraceConfigurator::TraceConfiguration::set_process_state);
   endpoint_tc_trace_conf.def_readwrite("thread_state", &EndpointTraceConfigurator::TraceConfiguration::thread_state);
   // For some reason, assigning into tread_state directly didn't work, make a simple assign function.
-  endpoint_tc_trace_conf.def("add_thread_entry", [](EndpointTraceConfigurator::TraceConfiguration& v, unsigned long id, bool state)
-  {
-    v.thread_state[id] = state;
-  });
+  endpoint_tc_trace_conf.def("add_thread_entry", [](EndpointTraceConfigurator::TraceConfiguration& v, unsigned long id,
+                                                    bool state) { v.thread_state[id] = state; });
 
-  endpoint_tc_trace_conf.def("to_dict", [](const EndpointTraceConfigurator::TraceConfiguration& p){
+  endpoint_tc_trace_conf.def("to_dict", [](const EndpointTraceConfigurator::TraceConfiguration& p) {
     auto dict = py::dict();
     dict["set_process_state"] = p.set_process_state;
     dict["process_state"] = p.process_state;
@@ -105,7 +103,6 @@ void add_scalopus_tracing(py::module& m)
     return dict;
   });
   // End EndpointTraceConfigurator
-
 
   py::module native = tracing.def_submodule("native", "The native specific components.");
   py::class_<EndpointNativeTraceSender, EndpointNativeTraceSender::Ptr, Endpoint> endpoint_native_trace_sender(

--- a/scalopus_python/scalopus/__main__.py
+++ b/scalopus_python/scalopus/__main__.py
@@ -128,7 +128,7 @@ def run_trace_configure(args):
     # perform manipulations as requested.
     relevant_ids = set(args.id)
     new_trace_state = args.state == "on"
-    new_unmatched_trace_state = args.unmatched_process == "on"
+    new_unmatched_trace_state = args.unmatched_pid == "on"
 
     # Retrieve active endpoints
     endpoints = poller.endpoints()
@@ -148,7 +148,7 @@ def run_trace_configure(args):
             new_state.set_process_state = True
             new_state.process_state = new_trace_state
         else:
-            if args.unmatched_process:
+            if args.unmatched_pid:
                 new_state.set_process_state = True
                 new_state.process_state = new_unmatched_trace_state
                 
@@ -229,7 +229,7 @@ if __name__ == "__main__":
         help="Configure the trace state.")
     trace_configure_parser.add_argument('state', choices=['on', 'off'],
         default=None, nargs="?", help="Matched id's will be set to this state.")
-    trace_configure_parser.add_argument('-u','--unmatched-process',default=None,
+    trace_configure_parser.add_argument('-u','--unmatched-pid',default=None,
         choices=['on', 'off'], nargs="?",
         help="Set unmatched process id's state to this value.")
     trace_configure_parser.add_argument("id", nargs="*", type=int,

--- a/scalopus_python/scalopus/__main__.py
+++ b/scalopus_python/scalopus/__main__.py
@@ -115,6 +115,9 @@ def run_discover(args):
                 print(doffset + "  {}    \"{}\"".format(thread_id, thread_name))
         print()
 
+def run_trace_configure(args):
+    pass
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -154,6 +157,10 @@ if __name__ == "__main__":
                                             "processes and show short info"
                                             " about them.")
     discover_parser.set_defaults(func=run_discover)
+
+    trace_configure_parser = subparsers.add_parser("trace_configure", help="Configure "
+                                            " a processes' trace state.")
+    trace_configure_parser.set_defaults(func=run_trace_configure)
 
     args = parser.parse_args()
 

--- a/scalopus_python/scalopus/__main__.py
+++ b/scalopus_python/scalopus/__main__.py
@@ -228,7 +228,7 @@ if __name__ == "__main__":
     trace_configure_parser = subparsers.add_parser("trace_configure",
         help="Configure the trace state.")
     trace_configure_parser.add_argument('state', choices=['on', 'off'],
-                                        default=None, nargs="?")
+        default=None, nargs="?", help="Matched id's will be set to this state.")
     trace_configure_parser.add_argument('-u','--unmatched-process',default=None,
         choices=['on', 'off'], nargs="?",
         help="Set unmatched process id's state to this value.")

--- a/scalopus_python/scalopus/tracing.py
+++ b/scalopus_python/scalopus/tracing.py
@@ -40,6 +40,7 @@ getProcessState = tracing.getProcessState
 setProcessState = tracing.setProcessState
 MarkLevel = tracing.MarkLevel
 EndpointTraceMapping = tracing.EndpointTraceMapping
+EndpointTraceConfigurator = tracing.EndpointTraceConfigurator
 EndpointNativeTraceSender = tracing.native.EndpointNativeTraceSender
 NativeTraceProvider = tracing.native.NativeTraceProvider
 

--- a/scalopus_tracing/CMakeLists.txt
+++ b/scalopus_tracing/CMakeLists.txt
@@ -4,6 +4,7 @@ include(FindThreads)
 
 add_library(scalopus_scope_tracing SHARED
   src/static_string_tracker.cpp
+  src/endpoint_trace_configurator.cpp
   src/endpoint_trace_mapping.cpp
   src/trace_configurator.cpp
   src/trace_configuration_raii.cpp

--- a/scalopus_tracing/include/scalopus_tracing/endpoint_trace_configurator.h
+++ b/scalopus_tracing/include/scalopus_tracing/endpoint_trace_configurator.h
@@ -48,6 +48,7 @@ public:
   struct TraceConfiguration
   {
     bool process_state{ false };                 //!< Are traces for this process enabled?
+    bool set_process_state{ false };             //!< Are we setting the process state?
     std::map<unsigned long, bool> thread_state;  //!< Thread state, true = tracing enabled.
     bool cmd_success{ false };
 

--- a/scalopus_tracing/include/scalopus_tracing/endpoint_trace_configurator.h
+++ b/scalopus_tracing/include/scalopus_tracing/endpoint_trace_configurator.h
@@ -52,7 +52,7 @@ public:
     std::map<unsigned long, bool> thread_state;  //!< Thread state, true = tracing enabled.
     bool cmd_success{ false };
 
-    operator bool()
+    operator bool() const
     {
       return cmd_success;
     }

--- a/scalopus_tracing/include/scalopus_tracing/endpoint_trace_configurator.h
+++ b/scalopus_tracing/include/scalopus_tracing/endpoint_trace_configurator.h
@@ -1,0 +1,88 @@
+/*
+  Copyright (c) 2018-2019, Ivor Wanders
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+  * Neither the name of the author nor the names of contributors may be used to
+    endorse or promote products derived from this software without specific
+    prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#ifndef SCALOPUS_TRACING_ENDPOINT_TRACE_CONFIGURATOR_H
+#define SCALOPUS_TRACING_ENDPOINT_TRACE_CONFIGURATOR_H
+
+#include <scalopus_interface/transport.h>
+#include <map>
+#include <string>
+
+namespace scalopus
+{
+/**
+ * @brief This endpoint provides the thread names and process name.
+ */
+class EndpointTraceConfigurator : public Endpoint
+{
+public:
+  using Ptr = std::shared_ptr<EndpointTraceConfigurator>;
+  static const char* name;
+
+  struct TraceConfiguration
+  {
+    bool process_state{ false };                 //!< Are traces for this process enabled?
+    std::map<unsigned long, bool> thread_state;  //!< Thread state, true = tracing enabled.
+    bool cmd_success{ false };
+
+    operator bool()
+    {
+      return cmd_success;
+    }
+  };
+
+  /**
+   * @brief Constructor for this endpoint.
+   */
+  EndpointTraceConfigurator() = default;
+
+  //  ------   Client ------
+  /**
+   * @brief Set trace state, only modifies threads which are present in the map.
+   */
+  TraceConfiguration setTraceState(const TraceConfiguration& state) const;
+
+  /**
+   * @brief Get the current trace state.
+   */
+  TraceConfiguration getTraceState() const;
+
+  /**
+   * @brief Function to create a new instance of this class and assign the transport to it.
+   */
+  static Ptr factory(const Transport::Ptr& transport);
+
+  // From the endpoint
+  std::string getName() const;
+  bool handle(Transport& server, const Data& request, Data& response);
+};
+
+}  // namespace scalopus
+
+#endif  // SCALOPUS_TRACING_ENDPOINT_TRACE_CONFIGURATOR_H

--- a/scalopus_tracing/include/scalopus_tracing/tracing.h
+++ b/scalopus_tracing/include/scalopus_tracing/tracing.h
@@ -33,6 +33,7 @@
 #include <scalopus_general/general.h>
 #include <scalopus_tracing/endpoint_native_trace_sender.h>
 #include <scalopus_tracing/endpoint_trace_mapping.h>
+#include <scalopus_tracing/endpoint_trace_configurator.h>
 #include <scalopus_tracing/trace_configurator.h>
 #include <scalopus_tracing/trace_macro.h>
 

--- a/scalopus_tracing/include/scalopus_tracing/tracing.h
+++ b/scalopus_tracing/include/scalopus_tracing/tracing.h
@@ -32,8 +32,8 @@
 
 #include <scalopus_general/general.h>
 #include <scalopus_tracing/endpoint_native_trace_sender.h>
-#include <scalopus_tracing/endpoint_trace_mapping.h>
 #include <scalopus_tracing/endpoint_trace_configurator.h>
+#include <scalopus_tracing/endpoint_trace_mapping.h>
 #include <scalopus_tracing/trace_configurator.h>
 #include <scalopus_tracing/trace_macro.h>
 

--- a/scalopus_tracing/src/endpoint_trace_configurator.cpp
+++ b/scalopus_tracing/src/endpoint_trace_configurator.cpp
@@ -1,0 +1,151 @@
+/*
+  Copyright (c) 2018-2019, Ivor Wanders
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+  * Neither the name of the author nor the names of contributors may be used to
+    endorse or promote products derived from this software without specific
+    prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include <scalopus_tracing/endpoint_trace_configurator.h>
+#include <scalopus_tracing/trace_configurator.h>
+#include <iostream>
+#include <nlohmann/json.hpp>
+
+namespace scalopus
+{
+using json = nlohmann::json;
+
+const char* EndpointTraceConfigurator::name = "trace_configurator";
+
+std::string EndpointTraceConfigurator::getName() const
+{
+  return name;
+}
+
+void to_json(json& j, const EndpointTraceConfigurator::TraceConfiguration& state)
+{
+  j["p"] = state.process_state;
+  j["t"] = state.thread_state;
+}
+
+void from_json(const json& j, EndpointTraceConfigurator::TraceConfiguration& state)
+{
+  j.at("p").get_to(state.process_state);
+  j.at("t").get_to(state.thread_state);
+}
+
+EndpointTraceConfigurator::TraceConfiguration
+EndpointTraceConfigurator::setTraceState(const TraceConfiguration& state) const
+{
+  // send message...
+  if (transport_ == nullptr)
+  {
+    throw communication_error("No transport provided to endpoint, cannot communicate.");
+  }
+
+  json request = json::object();
+  request["cmd"] = "set";
+  request["state"] = state;
+  auto future_ptr = transport_->request(getName(), json::to_bson(request));
+
+  if (future_ptr->wait_for(std::chrono::milliseconds(200)) == std::future_status::ready)
+  {
+    json jdata = json::from_bson(future_ptr->get());  // This line may throw
+    auto new_state = jdata.at("state").get<TraceConfiguration>();
+    new_state.cmd_success = true;
+    return new_state;
+  }
+  return {};
+}
+
+EndpointTraceConfigurator::TraceConfiguration EndpointTraceConfigurator::getTraceState() const
+{
+  // send message...
+  if (transport_ == nullptr)
+  {
+    throw communication_error("No transport provided to endpoint, cannot communicate.");
+  }
+
+  json request = json::object();
+  request["cmd"] = "get";
+  auto future_ptr = transport_->request(getName(), json::to_bson(request));
+
+  if (future_ptr->wait_for(std::chrono::milliseconds(200)) == std::future_status::ready)
+  {
+    json jdata = json::from_bson(future_ptr->get());  // This line may throw
+    auto new_state = jdata.at("state").get<TraceConfiguration>();
+    new_state.cmd_success = true;
+    return new_state;
+  }
+  return {};
+}
+
+bool EndpointTraceConfigurator::handle(Transport& /* server */, const Data& request, Data& response)
+{
+  json req = json::from_bson(request);
+  auto configurator_instance = TraceConfigurator::getInstance();
+
+  auto thread_map = configurator_instance->getThreadMap();
+  auto process_state = configurator_instance->getProcessStatePtr();
+
+  if (req.at("cmd").get<std::string>() == "set")
+  {
+    const auto new_state = req.at("state").get<TraceConfiguration>();
+    // Store the new process state
+    process_state->store(new_state.process_state);
+
+    // Iterate over the provided thread id's and try to set their state.
+    for (const auto& k_v : new_state.thread_state)
+    {
+      auto it = thread_map.find(k_v.first);
+      if (it != thread_map.end())
+      {
+        it->second->store(k_v.second);
+      }
+    }
+  }
+
+  // Now, create a response with the current state.
+  json jdata = json::object();
+  TraceConfiguration updated_state;
+
+  // Store the process state
+  updated_state.process_state = process_state->load();
+
+  // Store the thread state
+  std::for_each(thread_map.begin(), thread_map.end(),
+                [&](const auto& p) { updated_state.thread_state[p.first] = p.second->load(); });
+  jdata["state"] = updated_state;
+  response = json::to_bson(jdata);
+  return true;
+}
+
+EndpointTraceConfigurator::Ptr EndpointTraceConfigurator::factory(const Transport::Ptr& transport)
+{
+  auto endpoint = std::make_shared<EndpointTraceConfigurator>();
+  endpoint->setTransport(transport);
+  return endpoint;
+}
+
+}  // namespace scalopus

--- a/scalopus_tracing/src/endpoint_trace_configurator.cpp
+++ b/scalopus_tracing/src/endpoint_trace_configurator.cpp
@@ -46,12 +46,14 @@ std::string EndpointTraceConfigurator::getName() const
 void to_json(json& j, const EndpointTraceConfigurator::TraceConfiguration& state)
 {
   j["p"] = state.process_state;
+  j["sp"] = state.set_process_state;
   j["t"] = state.thread_state;
 }
 
 void from_json(const json& j, EndpointTraceConfigurator::TraceConfiguration& state)
 {
   j.at("p").get_to(state.process_state);
+  j.at("sp").get_to(state.set_process_state);
   j.at("t").get_to(state.thread_state);
 }
 
@@ -113,7 +115,10 @@ bool EndpointTraceConfigurator::handle(Transport& /* server */, const Data& requ
   {
     const auto new_state = req.at("state").get<TraceConfiguration>();
     // Store the new process state
-    process_state->store(new_state.process_state);
+    if (new_state.set_process_state)
+    {
+      process_state->store(new_state.process_state);
+    }
 
     // Iterate over the provided thread id's and try to set their state.
     for (const auto& k_v : new_state.thread_state)

--- a/scalopus_transport/src/transport_unix.cpp
+++ b/scalopus_transport/src/transport_unix.cpp
@@ -115,6 +115,7 @@ bool TransportUnix::connect(std::size_t pid)
   std::stringstream ss;
   ss << "" << pid << "_scalopus";
   std::strncpy(socket_config.sun_path + 1, ss.str().c_str(), sizeof(socket_config.sun_path) - 2);
+  client_pid_ = pid;
 
   std::size_t path_length = sizeof(socket_config.sun_family) + strlen(socket_config.sun_path + 1) + 1;
   if (::connect(client_fd_, reinterpret_cast<sockaddr*>(&socket_config), static_cast<unsigned int>(path_length)) == -1)
@@ -406,7 +407,14 @@ bool TransportUnix::processMsg(const protocol::Msg& request, protocol::Msg& resp
 
 Destination::Ptr TransportUnix::getAddress()
 {
-  return std::make_shared<DestinationUnix>(::getpid());
+  if (server_fd_ != 0)
+  {
+    return std::make_shared<DestinationUnix>(::getpid());
+  }
+  else
+  {
+    return std::make_shared<DestinationUnix>(client_pid_);
+  }
 }
 
 // Methods for the factory

--- a/scalopus_transport/src/transport_unix.h
+++ b/scalopus_transport/src/transport_unix.h
@@ -87,6 +87,7 @@ private:
   void work();          //!< Function for the worker thread.
   int server_fd_{ 0 };  //!< File descriptor from the server bind.
   int client_fd_{ 0 };  //!< File descriptor from connecting to a server.
+  std::size_t client_pid_{ 0 };
 
   bool running_{ false };  //!< Boolean to quit the worker thread.
 


### PR DESCRIPTION
In this PR:

- Endpoint for the `TraceConfigurator`, this allows setting thread state and state of individual threads.
- Created `discover` command for the Scalopus CLI (`python -m scalopus discover`).
- Created `trace_configure` command for the Scalopus CLI (`python -m scalopus trace_configure`).

Discover lists the output of the `ProcessInfo` and `Introspect` endpoints, output is like:
```
PID:   9918  "./scalopus_examples/random_callstacks_native"
             Endpoints: 
               introspect
               native_trace_sender
               process_info
               scope_tracing
               trace_configurator
             Threads:
               140135697303296    "Thread 0x0"
               140135745300608    "main"
```


The `trace_configure` command allows configuring whether traces are enabled for a specific process id or thread id.
The output is simpler:
```
PID:   9918  "./scalopus_examples/random_callstacks_native"
          140135697303296    "Thread 0x0"
          140135745300608    "main"
```
And process id is colored green if traces are enabled for this process. Thread id is colored green if traces are enabled for that thread. Blue if they are disabled.

One can enable output from process id 9918 with `python3 -m scalopus trace_configure on 9918`. Or disable all processes except 123 with `python3 -m scalopus trace_configure --unmatched-pid off on 123`. It's pretty crude, but should get the job done for now.

Builds on top of #1, see [this compare](https://github.com/iwanders/scalopus/compare/fix-configurator-destruction...support-toggling-processes) for just the changes that add the configurability.