### PR TITLE
Sort events

### DIFF
--- a/scalopus_tracing/src/native/native_trace_source.cpp
+++ b/scalopus_tracing/src/native/native_trace_source.cpp
@@ -141,6 +141,12 @@ std::vector<json> NativeTraceSource::finishInterval()
     }
   }
 
+  // Sort res by "ts" because sometimes the "E"nd events are out of order wrt the "B"egin, leading to unfinished scope
+  // events.
+  std::stable_sort(res.begin(), res.end(), [](const json& lhs, const json& rhs) {
+    return lhs.at("ts").get<double>() < rhs.at("ts").get<double>();
+  });
+
   return res;
 }
 


### PR DESCRIPTION
If we run `std::is_sorted` it returns `false` sometimes, confirming the event aren't always sorted.

`std::stable_sort` is used just in case a pair of **'B'** (begin) and **'E'** (end) events has the same **'ts'** time. This guarantees the original order is maintained in that case, although it could still be the case that the **'E'** event is before it's corresponding **'B'** event. Fortunately, this rarely
happens in practice. Maybe we could just use `std::sort` for this same reason?! :thinking: 