### PR TITLE
Release the gil when joining the thread in unit test.

### DIFF
--- a/scalopus_python/lib/python_test_helpers.cpp
+++ b/scalopus_python/lib/python_test_helpers.cpp
@@ -74,6 +74,7 @@ public:
   }
   void join()
   {
+    py::gil_scoped_release release;
     if (thread_running_)
     {
       thread_.join();


### PR DESCRIPTION
This is an attempt to fix the deadlocking unit test. We need to release the gil when `.join()` is called from the Python side.