### PR TITLE
Use improved destructor callback.

### DIFF
--- a/scalopus_general/include/scalopus_general/destructor_callback.h
+++ b/scalopus_general/include/scalopus_general/destructor_callback.h
@@ -34,24 +34,60 @@
 
 namespace scalopus
 {
+
 /**
- * @brief Object that calls a function on destruction.
+ * @brief Templated struct to wrap a callback function to be called on the objects' destruction.
  */
-struct DestructorCallback
+template <typename Callback>
+struct DestructorCallbackImpl
 {
 public:
-  DestructorCallback(std::function<void()>&& fun) : callback_(fun)
+  DestructorCallbackImpl(Callback&& fun) : callback_(fun)
   {
   }
 
-  ~DestructorCallback()
+  DestructorCallbackImpl(const Callback& fun) : callback_(fun)
   {
-    callback_();
+  }
+
+  // Call it from this void function to enforce the void() signature of the callback.
+  void destroyer()
+  {
+      return callback_();
+  }
+
+  ~DestructorCallbackImpl()
+  {
+    destroyer();
   }
 
 private:
-  std::function<void()> callback_;
+  Callback callback_;
 };
+
+/**
+ * @brief Creates an object that will call the provided callback function when it goes out of scope.
+ * @param callback The function that will be called when the returned object goes out of scope. Signature should be
+ *        void(void).
+ * @return An object that will invoke callback when it is destroyed.
+ */
+template <typename Callback>
+DestructorCallbackImpl<Callback> DestructorCallback(Callback&& callback)
+{
+    return DestructorCallbackImpl<Callback>(callback);
+}
+
+/**
+ * @brief Creates an object that will call the provided callback function when it goes out of scope.
+ * @param callback The function that will be called when the returned object goes out of scope. Signature should be
+ *        void(void).
+ * @return An object that will invoke callback when it is destroyed.
+ */
+template <typename Callback>
+DestructorCallbackImpl<Callback> DestructorCallback(const Callback& callback)
+{
+    return DestructorCallbackImpl<Callback>(callback);
+}
 }  // namespace scalopus
 
 #endif  // SCALOPUS_DESTRUCTOR_CALLBACK_H

--- a/scalopus_general/include/scalopus_general/destructor_callback.h
+++ b/scalopus_general/include/scalopus_general/destructor_callback.h
@@ -34,7 +34,6 @@
 
 namespace scalopus
 {
-
 /**
  * @brief Templated struct to wrap a callback function to be called on the objects' destruction.
  */
@@ -53,7 +52,7 @@ public:
   // Call it from this void function to enforce the void() signature of the callback.
   void destroyer()
   {
-      return callback_();
+    return callback_();
   }
 
   ~DestructorCallbackImpl()
@@ -74,7 +73,7 @@ private:
 template <typename Callback>
 DestructorCallbackImpl<Callback> DestructorCallback(Callback&& callback)
 {
-    return DestructorCallbackImpl<Callback>(callback);
+  return DestructorCallbackImpl<Callback>(callback);
 }
 
 /**
@@ -86,7 +85,7 @@ DestructorCallbackImpl<Callback> DestructorCallback(Callback&& callback)
 template <typename Callback>
 DestructorCallbackImpl<Callback> DestructorCallback(const Callback& callback)
 {
-    return DestructorCallbackImpl<Callback>(callback);
+  return DestructorCallbackImpl<Callback>(callback);
 }
 }  // namespace scalopus
 

--- a/scalopus_general/src/thread_name_tracker.cpp
+++ b/scalopus_general/src/thread_name_tracker.cpp
@@ -42,7 +42,7 @@ void ThreadNameTracker::setCurrentName(const std::string& name)
 {
   const auto tid = static_cast<unsigned long>(pthread_self());
   // Register a destructor callback such that the thread gets removed from the map when the thread exits.
-  thread_local DestructorCallback cleanup{ [this, tid]() { erase(tid); } };
+  thread_local auto cleanup = DestructorCallback([this, tid]() { erase(tid); });
   setThreadName(tid, name);
 }
 

--- a/scalopus_tracing/src/native/tracepoint_collector_native.cpp
+++ b/scalopus_tracing/src/native/tracepoint_collector_native.cpp
@@ -55,13 +55,13 @@ tracepoint_collector_types::ScopeBufferPtr TracePointCollectorNative::getBuffer(
   const auto tid = static_cast<unsigned long>(pthread_self());
   // Register a destructor callback such that the thread gets removed from the map when the thread exits.
   auto instance_pointer = getInstance();
-  thread_local DestructorCallback cleanup{ [instance = TracePointCollectorNative::WeakPtr(instance_pointer), tid]() {
+  thread_local auto cleanup = DestructorCallback( [instance = TracePointCollectorNative::WeakPtr(instance_pointer), tid]() {
     auto ptr = instance.lock();
     if (ptr != nullptr)
     {
       ptr->erase(tid);
     }
-  } };
+  } );
 
   if (exists(tid))
   {

--- a/scalopus_tracing/src/native/tracepoint_collector_native.cpp
+++ b/scalopus_tracing/src/native/tracepoint_collector_native.cpp
@@ -55,13 +55,14 @@ tracepoint_collector_types::ScopeBufferPtr TracePointCollectorNative::getBuffer(
   const auto tid = static_cast<unsigned long>(pthread_self());
   // Register a destructor callback such that the thread gets removed from the map when the thread exits.
   auto instance_pointer = getInstance();
-  thread_local auto cleanup = DestructorCallback( [instance = TracePointCollectorNative::WeakPtr(instance_pointer), tid]() {
-    auto ptr = instance.lock();
-    if (ptr != nullptr)
-    {
-      ptr->erase(tid);
-    }
-  } );
+  thread_local auto cleanup =
+      DestructorCallback([instance = TracePointCollectorNative::WeakPtr(instance_pointer), tid]() {
+        auto ptr = instance.lock();
+        if (ptr != nullptr)
+        {
+          ptr->erase(tid);
+        }
+      });
 
   if (exists(tid))
   {

--- a/scalopus_tracing/src/trace_configurator.cpp
+++ b/scalopus_tracing/src/trace_configurator.cpp
@@ -43,13 +43,13 @@ TraceConfigurator::AtomicBoolPtr TraceConfigurator::getThreadStatePtr()
 
   //  Register a destructor callback such that the thread gets removed from the map when the thread exits.
   auto instance_pointer = getInstance();
-  thread_local DestructorCallback cleanup{ [instance = TraceConfigurator::WeakPtr(instance_pointer), tid]() {
+  thread_local auto cleanup = DestructorCallback( [instance = TraceConfigurator::WeakPtr(instance_pointer), tid]() {
     auto ptr = instance.lock();
     if (ptr != nullptr)
     {
       ptr->removeThread(tid);
     }
-  } };
+  } );
   std::lock_guard<decltype(threads_map_mutex_)> lock(threads_map_mutex_);
   auto it = thread_state_.find(tid);
   if (it != thread_state_.end())

--- a/scalopus_tracing/src/trace_configurator.cpp
+++ b/scalopus_tracing/src/trace_configurator.cpp
@@ -43,13 +43,13 @@ TraceConfigurator::AtomicBoolPtr TraceConfigurator::getThreadStatePtr()
 
   //  Register a destructor callback such that the thread gets removed from the map when the thread exits.
   auto instance_pointer = getInstance();
-  thread_local auto cleanup = DestructorCallback( [instance = TraceConfigurator::WeakPtr(instance_pointer), tid]() {
+  thread_local auto cleanup = DestructorCallback([instance = TraceConfigurator::WeakPtr(instance_pointer), tid]() {
     auto ptr = instance.lock();
     if (ptr != nullptr)
     {
       ptr->removeThread(tid);
     }
-  } );
+  });
   std::lock_guard<decltype(threads_map_mutex_)> lock(threads_map_mutex_);
   auto it = thread_state_.find(tid);
   if (it != thread_state_.end())


### PR DESCRIPTION
This changes the destructor callback object such that the `std::function` part becomes unnecessary. This allows the optimizer to basically eliminate all the code surrounding the callback itself.

Credit to @jasonimercer, he came up with this way of doing it after we discussed whether a callback on the destruction of a `unique_ptr` to an integer was better, or whether the previous implementation in Scalopus was better. [Godbolt](https://godbolt.org/z/NjQed0) link shows this optimises very well.

Review @efernandez. 