### PR TITLE
Sync Seasocks back to upstream.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/nlohmann/json
 [submodule "thirdparty/seasocks"]
 	path = thirdparty/seasocks
-	url = https://github.com/iwanders/seasocks
+	url = https://github.com/mattgodbolt/seasocks
 [submodule "thirdparty/pybind11"]
 	path = thirdparty/pybind11
 	url = https://github.com/pybind/pybind11


### PR DESCRIPTION
Just syncing back to the latest Seasocks now that https://github.com/mattgodbolt/seasocks/pull/129 is merged. I want to be on upstream as much as possible such that I don't wonder why I'm on a fork somewhere in the future.

Fyi @jasonimercer, @efernandez, we'll sync internal only when there's other changes we want.