### PR TITLE
Prevent possible crash on startup.

### DIFF
--- a/scalopus_interface/include/scalopus_interface/endpoint.h
+++ b/scalopus_interface/include/scalopus_interface/endpoint.h
@@ -88,7 +88,7 @@ public:
    */
   // static Endpoint::Ptr factory(const std::shared_ptr<Transport>& transport);
 protected:
-  Transport* transport_;  // Transport has a shared pointer to the endpoint, so it cannot go out of scope before this.
+  Transport* transport_{ nullptr };  // Transport has a shared pointer to the endpoint, so it cannot go out of scope before this.
 };
 
 }  // namespace scalopus


### PR DESCRIPTION
We saw crashes on [this](https://github.com/iwanders/scalopus/blob/master/scalopus_tracing/src/native/endpoint_native_trace_sender.cpp#L100) line, which can only happen if `transport_` is bad.

The `Transport` has a shared pointer to the `Endpoints`, so the `Transport` can only go out of scope after the endpoints, not before it. Because the pointer was not initialised it could happen on startup, if `transport_` was not a nullptr and not yet assigned to the valid `Transport` we could interact with it when traces are produced before `setTransport` is called.

Also updated cbor to include https://github.com/iwanders/cbor/pull/6

@efernandez, @jasonimercer