### PR TITLE
Return from processing if stdout is nullptr.

### DIFF
--- a/scalopus_general/src/general_source.cpp
+++ b/scalopus_general/src/general_source.cpp
@@ -42,10 +42,10 @@ std::vector<json> GeneralSource::finishInterval()
   provider_->updateMapping();
 
   std::vector<json> result;
-  auto mapping = provider_->getMapping();
+  const auto mapping = provider_->getMapping();
 
   // Iterate over all mappings by process ID.
-  for (const auto pid_process_info : mapping)
+  for (const auto& pid_process_info : mapping)
   {
     // make a metadata entry to name a process.
     json process_entry;
@@ -57,7 +57,7 @@ std::vector<json> GeneralSource::finishInterval()
     result.push_back(process_entry);
 
     // For all thread mappings, make a metadata entry to name the thread.
-    for (const auto thread_mapping : pid_process_info.second.threads)
+    for (const auto& thread_mapping : pid_process_info.second.threads)
     {
       json tid_entry;
       tid_entry["tid"] = thread_mapping.first;

--- a/scalopus_tracing/include_consumer/scalopus_tracing/babeltrace_parser.h
+++ b/scalopus_tracing/include_consumer/scalopus_tracing/babeltrace_parser.h
@@ -99,7 +99,7 @@ public:
   static CTFEvent parse(std::string line);
 
 private:
-  std::atomic_bool processing_;  //! Bool to check on each while loop in the process function.
+  std::atomic_bool processing_{ false };  //! Bool to check on each while loop in the process function.
 
   std::mutex mutex_;                                             //! Mutex for the recording sessions set.
   std::set<std::shared_ptr<EventCallback>> sessions_recording_;  //! Set of sessions that are actively recording.

--- a/scalopus_tracing/src/lttng/babeltrace_parser.cpp
+++ b/scalopus_tracing/src/lttng/babeltrace_parser.cpp
@@ -54,7 +54,7 @@ void BabeltraceParser::process(FILE* stdout)
 {
   if (stdout == nullptr)
   {
-    logger_("[BabeltraceParser] Incorrect filepointer for stdout, quitting parser.");
+    logger_("[BabeltraceParser] Incorrect file pointer for stdout, quitting parser.");
     return;
   }
 

--- a/scalopus_tracing/src/lttng/babeltrace_parser.cpp
+++ b/scalopus_tracing/src/lttng/babeltrace_parser.cpp
@@ -52,6 +52,12 @@ void BabeltraceParser::setLogger(LoggingFunction logger)
 
 void BabeltraceParser::process(FILE* stdout)
 {
+  if (stdout == nullptr)
+  {
+    logger_("[BabeltraceParser] Incorrect filepointer for stdout, quitting parser.");
+    return;
+  }
+
   // start the processing.
   processing_.store(true);
   std::array<char, 1024> tmp;


### PR DESCRIPTION
Somehow the stdout handed in was a nullptr on a running system, this prevents trying to interact with that bad pointer in the first place.

I failed to reproduce this locally, even when making a subprocess that immediately returned and adding a sleep to ensure the subprocess exited before stdout was read.

Fyi @jasonimercer, @efernandez , @servos , CORE-17089