### PR TITLE
Crash in CTFEvent

### DIFF
--- a/scalopus_catapult/CMakeLists.txt
+++ b/scalopus_catapult/CMakeLists.txt
@@ -27,6 +27,13 @@ add_executable(scalopus_catapult_server src/scalopus_catapult_server.cpp)
 target_link_libraries(scalopus_catapult_server PRIVATE Scalopus::scalopus_catapult)
 target_compile_options(scalopus_catapult_server PRIVATE ${SCALOPUS_COMPILE_OPTIONS})
 
+if (SCALOPUS_TRACING_HAVE_BUILT_LTTNG)
+  target_compile_definitions(scalopus_catapult_server
+    PRIVATE
+      SCALOPUS_TRACING_HAVE_LTTNG=1
+  )
+endif()
+
 
 
 export(

--- a/scalopus_tracing/src/lttng/ctfevent.cpp
+++ b/scalopus_tracing/src/lttng/ctfevent.cpp
@@ -50,24 +50,47 @@ CTFEvent::CTFEvent(std::string line)
   // Extract the timestamp, its between []
   size_t start_pos = line.find("[");
   size_t end_pos = line.find("]");
+  if (start_pos == std::string::npos || end_pos == std::string::npos)
+  {
+    return;
+  }
   std::string timestamp_str = line.substr(start_pos + 1, end_pos - 1);
-  timestamp_ = std::stod(timestamp_str);
+  try
+  {
+    timestamp_ = std::stod(timestamp_str);
+  }
+  catch (const std::invalid_argument& e)
+  {
+    return;
+  }
 
   // Go for the hostname, this is the first thing between spaces.
   start_pos = end_pos;
   start_pos = line.find(" ", start_pos);
   end_pos = line.find(" ", start_pos + 1);
+  if (start_pos == std::string::npos || end_pos == std::string::npos)
+  {
+    return;
+  }
   hostname_ = line.substr(start_pos + 1, end_pos - start_pos - 1);
 
   // Extract the trace point specification, it's the third entry between spaces.
   start_pos = end_pos;
   start_pos = line.find(" ", start_pos);
   end_pos = line.find(" ", start_pos + 1);
+  if (start_pos == std::string::npos || end_pos == std::string::npos)
+  {
+    return;
+  }
   // -1 for removal of space, -1 for removal of ':'
   std::string trace_point = line.substr(start_pos + 1, end_pos - start_pos - 1 - 1);
 
   // Split the tracepoint in domain and name.
   size_t split_point = trace_point.find(":");
+  if (split_point == std::string::npos)
+  {
+    return;
+  }
   tracepoint_domain_ = trace_point.substr(0, split_point);
   tracepoint_name_ = trace_point.substr(split_point + 1, trace_point.size() - split_point);
 
@@ -75,18 +98,30 @@ CTFEvent::CTFEvent(std::string line)
   start_pos = end_pos;
   start_pos = line.find("{", start_pos);
   end_pos = line.find("}", start_pos + 1);
+  if (start_pos == std::string::npos || end_pos == std::string::npos)
+  {
+    return;
+  }
   std::string stream_context = line.substr(start_pos + 2, end_pos - start_pos - 1 - 2);
 
   // Obtain the event context between the curly braces.
   start_pos = end_pos;
   start_pos = line.find("{", start_pos);
   end_pos = line.find("}", start_pos + 1);
+  if (start_pos == std::string::npos || end_pos == std::string::npos)
+  {
+    return;
+  }
   std::string event_context = line.substr(start_pos + 2, end_pos - start_pos - 1 - 2);
 
   // Obtain the trace data between the curly braces.
   start_pos = end_pos;
   start_pos = line.find("{", start_pos);
   end_pos = line.find("}", start_pos + 1);
+  if (start_pos == std::string::npos || end_pos == std::string::npos)
+  {
+    return;
+  }
   std::string trace_data = line.substr(start_pos + 2, end_pos - start_pos - 1 - 2);
 
   // Make a lambda that can convert the syntax between the curly braces (comma separated values) into a map of integers.

--- a/scalopus_tracing/test/test_ctfevent.cpp
+++ b/scalopus_tracing/test/test_ctfevent.cpp
@@ -39,7 +39,8 @@ void test(const A& a, const B& b)
     exit(1);
   }
 }
-int main(int /* argc */, char** /* argv */)
+
+void test_expected()
 {
   std::string line{ "[1544361620.739021131] eagle scalopus_scope_id:exit: { cpu_id = 2 }, { vpid = 14897, pthread_id = "
                     "139688084124608 }, { id = 4144779573 }" };
@@ -51,5 +52,17 @@ int main(int /* argc */, char** /* argv */)
   test(event.domain(), "scalopus_scope_id");
   test(event.name(), "exit");
   test(event.eventData().at("id"), 4144779573U);
+}
+
+void test_unexpected()
+{
+  std::string line{ "[scalopus] Cleaning up transport to: 404305\n" };
+  scalopus::CTFEvent event{ line };  // should not throw.
+}
+
+int main(int /* argc */, char** /* argv */)
+{
+  test_expected();
+  test_unexpected();
   return 0;
 }


### PR DESCRIPTION
We observed a crash in CTFEvent, somehow the babeltrace parser ended up interpreting `[scalopus] Cleaning up transport to: 404305\n`.

Fix is two-fold:
1. Making the `CTFEvent` parsing more defensive, such that on bad input it will just yield a mostly empty event.
2. Disabling the lttng provider / babeltrace parser subprocess from the catapult server. Basically when lttng tracepoints are not compiled, we don't add the provider.

CORE-17566.

FYI @jasonimercer, @efernandez