### PR TITLE
Introduce a container for orphaned thread event buffers.

### DIFF
--- a/scalopus_general/include/scalopus_general/internal/thread_name_tracker.h
+++ b/scalopus_general/include/scalopus_general/internal/thread_name_tracker.h
@@ -59,6 +59,5 @@ public:
    */
   void setThreadName(unsigned long thread_id, const std::string& name);
 };
-
 }  // namespace scalopus
 #endif  // SCALOPUS_SCOPE_INTERNAL_THREAD_NAME_TRACKER_H

--- a/scalopus_general/include/scalopus_general/map_tracker.h
+++ b/scalopus_general/include/scalopus_general/map_tracker.h
@@ -43,9 +43,7 @@ template <typename Key, typename Value>
 class MapTracker
 {
 public:
-  MapTracker(MapTracker const&) = delete;      //! Delete the copy constructor.
-  void operator=(MapTracker const&) = delete;  //! Delete the assigment operator.
-
+  using MapType = std::unordered_map<Key, Value>;
   /**
    * @brief Function to insert an key->value pair. Is thread safe.
    * @param key The key to store in the map.
@@ -107,10 +105,6 @@ public:
 private:
   std::unordered_map<Key, Value> mapping_;
   mutable std::shared_timed_mutex mutex_;  //! Mutex for the mapping container.
-
-protected:
-  //! Make constructor private such that we can ensure it is a singleton.
-  MapTracker() = default;
 };
 }  // namespace scalopus
 

--- a/scalopus_tracing/src/native/endpoint_native_trace_sender.cpp
+++ b/scalopus_tracing/src/native/endpoint_native_trace_sender.cpp
@@ -79,7 +79,7 @@ void EndpointNativeTraceSender::work()
   while (running_)
   {
     // First, retrieve the orphaned buffers.
-    auto tid_buffers = collector.retrieveOrphanedBuffers();
+    auto tid_buffers = collector.retrieveAndClearOrphanedBuffers();
     // Then, append to that the active buffers.
     for (const auto& active_tid_buffer : collector.getActiveMap())
     {

--- a/scalopus_tracing/src/native/tracepoint_collector_native.cpp
+++ b/scalopus_tracing/src/native/tracepoint_collector_native.cpp
@@ -64,6 +64,9 @@ tracepoint_collector_types::ScopeBufferPtr TracePointCollectorNative::getBuffer(
           {
             // We have a buffer for this thread, we must retrieve the buffer and place it into the orphans list.
             auto buffer = ptr->active_tid_buffers_.getValue(tid);
+
+            // Do not check if it is empty, if for some reason tracepoints are still inserted into the buffer
+            // by other thread_local's that have tracepoints, we will still be collecting them.
             {
               std::lock_guard<std::mutex> lock{ptr->orphaned_mutex_};
               ptr->orphaned_tid_buffers_.emplace_back(tid, std::move(buffer));

--- a/scalopus_tracing/src/native/tracepoint_collector_native.cpp
+++ b/scalopus_tracing/src/native/tracepoint_collector_native.cpp
@@ -102,7 +102,7 @@ TracePointCollectorNative::BufferMap::MapType TracePointCollectorNative::getActi
   return active_tid_buffers_.getMap();
 }
 
-TracePointCollectorNative::BufferVector TracePointCollectorNative::retrieveOrphanedBuffers()
+TracePointCollectorNative::BufferVector TracePointCollectorNative::retrieveAndClearOrphanedBuffers()
 {
   BufferVector tmp;
   std::lock_guard<std::mutex> lock{orphaned_mutex_};

--- a/scalopus_tracing/src/native/tracepoint_collector_native.h
+++ b/scalopus_tracing/src/native/tracepoint_collector_native.h
@@ -160,7 +160,7 @@ public:
   /**
    * @brief Retrieve the orphaned buffers and clear them.
    */
-  BufferVector retrieveOrphanedBuffers();
+  BufferVector retrieveAndClearOrphanedBuffers();
 
 private:
   TracePointCollectorNative() = default;
@@ -179,7 +179,6 @@ private:
    *  @brief Thread safe map that tracks the event buffers per thread for currently active threads.
    */
   BufferMap active_tid_buffers_;
-
 
   mutable std::mutex orphaned_mutex_; //!< Mutex for the orphaned_tid_buffers_
 


### PR DESCRIPTION
We introduce a container for orphaned thread event buffers. This ensures that any events they still hold aren't removed when we erase the event form the map.

Resolves #18 