### PR TITLE
Add the CatapultRecorder class.

### DIFF
--- a/scalopus_catapult/CMakeLists.txt
+++ b/scalopus_catapult/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(scalopus_catapult SHARED
   src/catapult_backend.cpp
   src/catapult_server.cpp
   src/trace_session.cpp
+  src/catapult_recorder.cpp
 )
 
 target_include_directories(scalopus_catapult

--- a/scalopus_catapult/README.md
+++ b/scalopus_catapult/README.md
@@ -17,6 +17,11 @@ calling `makeSource()` on all providers. This `TraceSession` handles the actual 
 will call `startInterval` and `finishInterval` on all the sources. Ultimately chunking the collected trace events and
 sending them to the trace viewer.
 
+The [CatapultRecorder](/scalopus_catapult/include/scalopus_catapult/catapult_recorder.h) can be used to collect the
+tracepoints from providers without running the catapult server. Combined with a transport that connects to the running
+process, this can be used to collect tracepoints during the lifetime of the process and write these to a file on process
+exit. This is shown in the `embedded_catapult_recorder` example in the example directory.
+
 ## scalopus_catapult_server
 
 Besides the `scalopus_catapult` shared object, this package builds the `scalopus_catapult_server` binary that can be

--- a/scalopus_catapult/include/scalopus_catapult/catapult_recorder.h
+++ b/scalopus_catapult/include/scalopus_catapult/catapult_recorder.h
@@ -1,0 +1,110 @@
+/*
+  Copyright (c) 2018-2019, 2021, Ivor Wanders
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+  * Neither the name of the author nor the names of contributors may be used to
+    endorse or promote products derived from this software without specific
+    prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#ifndef SCALOPUS_CATAPULT_CATAPULT_RECORDER_H
+#define SCALOPUS_CATAPULT_CATAPULT_RECORDER_H
+
+#include <scalopus_interface/trace_event_provider.h>
+#include <thread>
+#include <atomic>
+#include <mutex>
+
+namespace scalopus
+{
+
+/**
+ * @brief The catapult recorder, runs a recording of tracepoints and allows writing to file on destruction.
+ */
+class CatapultRecorder
+{
+public:
+  using Ptr = std::shared_ptr<CatapultRecorder>;
+
+  /**
+   * @brief Construct the catapult recorder.
+   */
+  CatapultRecorder() = default;
+
+  /**
+   * @brief Add a provider, this should be done before the start is invoked and the sources are made.
+   */
+  void addProvider(TraceEventProvider::Ptr provider);
+
+  /**
+   * @brief Start the worker and make the sources from the providers.
+   */
+  void start();
+
+  /**
+   * @brief Stop the worker and clear the sources.
+   */
+  void stop();
+
+  /**
+   * @brief Call startInterval on all the sources.
+   */
+  void startInterval();
+
+  /**
+   * @brief Call stopInterval on all the sources.
+   */
+  void stopInterval();
+
+  /**
+   * @brief If this file is specified the recorder will dump the entire recording to this file when it is destroyed.
+   */
+  void setupDumpFile(const std::string& file_path);
+
+  /**
+   * @brief Stop the interval and write to this file.
+   */
+  void writeToFile(const std::string& file_path);
+
+  /**
+   * @brief stop the interval, finalize it to collect the trace events and return the json serialized results.
+   */
+  std::string collectEvents();
+
+  // Destructor, used to dump the file.
+  ~CatapultRecorder();
+private:
+  std::vector<TraceEventProvider::Ptr> providers_;
+  std::vector<TraceEventSource::Ptr> sources_;
+
+  std::string dump_file_path_;
+
+  std::thread worker_;
+  void loop();
+  std::atomic_bool running_{ false };
+  std::mutex source_mutex_;
+  
+};
+
+}  // namespace scalopus
+#endif  // SCALOPUS_CATAPULT_CATAPULT_RECORDER_H

--- a/scalopus_catapult/include/scalopus_catapult/catapult_recorder.h
+++ b/scalopus_catapult/include/scalopus_catapult/catapult_recorder.h
@@ -31,13 +31,12 @@
 #define SCALOPUS_CATAPULT_CATAPULT_RECORDER_H
 
 #include <scalopus_interface/trace_event_provider.h>
-#include <thread>
 #include <atomic>
 #include <mutex>
+#include <thread>
 
 namespace scalopus
 {
-
 /**
  * @brief The catapult recorder, runs a recording of tracepoints and allows writing to file on destruction.
  */

--- a/scalopus_catapult/include/scalopus_catapult/catapult_recorder.h
+++ b/scalopus_catapult/include/scalopus_catapult/catapult_recorder.h
@@ -87,23 +87,26 @@ public:
   void writeToFile(const std::string& file_path);
 
   /**
-   * @brief stop the interval, finalize it to collect the trace events and return the json serialized results.
+   * @brief Stop the interval, finalize it to collect the trace events and return the json serialized results.
    */
   std::string collectEvents();
 
-  // Destructor, used to dump the file.
+  /**
+   * @brief Destructor, used to dump the file.
+   */
   ~CatapultRecorder();
+
 private:
+  void loop();  //!< Function the thread executes.
+
   std::vector<TraceEventProvider::Ptr> providers_;
   std::vector<TraceEventSource::Ptr> sources_;
 
   std::string dump_file_path_;
 
   std::thread worker_;
-  void loop();
   std::atomic_bool running_{ false };
   std::mutex source_mutex_;
-  
 };
 
 }  // namespace scalopus

--- a/scalopus_catapult/src/catapult_recorder.cpp
+++ b/scalopus_catapult/src/catapult_recorder.cpp
@@ -1,0 +1,158 @@
+/*
+  Copyright (c) 2018-2019, 2021, Ivor Wanders
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+  * Neither the name of the author nor the names of contributors may be used to
+    endorse or promote products derived from this software without specific
+    prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include "scalopus_catapult/catapult_recorder.h"
+#include <fstream>
+#include <sstream>
+
+namespace scalopus
+{
+void CatapultRecorder::loop()
+{
+  while(running_)
+  {
+    {
+      std::lock_guard<std::mutex> lock{source_mutex_};
+      for (auto& source : sources_)
+      {
+        source->work();
+      }
+    }
+
+    // Finally, block a bit just to prevent spinning.
+    // @TODO Think of a way to allow it to block here until there are messages or work needs to be done.
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+}
+
+void CatapultRecorder::stop()
+{
+  running_ = false;
+  worker_.join();
+  sources_.clear();
+}
+
+
+void CatapultRecorder::startInterval()
+{
+  std::lock_guard<std::mutex> lock{source_mutex_};
+  for (auto& source : sources_)
+  {
+    source->startInterval();
+  }
+}
+
+void CatapultRecorder::stopInterval()
+{
+  std::lock_guard<std::mutex> lock{source_mutex_};
+  for (auto& source : sources_)
+  {
+    source->stopInterval();
+  }
+}
+
+void CatapultRecorder::addProvider(TraceEventProvider::Ptr provider)
+{
+  providers_.push_back(provider);
+}
+
+void CatapultRecorder::start()
+{
+  if (running_)
+  {
+    return;
+  }
+  sources_.clear();
+  sources_.reserve(providers_.size());
+  // Add all the sources to the session
+  for (auto& provider : providers_)
+  {
+    sources_.push_back(provider->makeSource());
+  }
+  running_ = true;
+  worker_ = std::thread{[&]{loop();}};
+}
+
+
+void CatapultRecorder::setupDumpFile(const std::string& file_path)
+{
+  dump_file_path_ = file_path;
+}
+
+
+std::string CatapultRecorder::collectEvents()
+{
+  // Stop the interval first.
+  stopInterval();
+
+  // Then collect the events by calling finishInterval
+  std::vector<json> events;
+  {
+    std::lock_guard<std::mutex> lock{source_mutex_};
+    for (auto& source : sources_)
+    {
+      auto results = source->finishInterval();
+      events.insert(events.end(), results.begin(), results.end());
+    }
+  }
+
+  // And format it to json.
+  std::stringstream ss;
+  ss << "[\n";
+  bool has_added = false;
+  for (const auto& entry : events)
+  {
+    if (has_added)
+    {
+      ss << ",\n";
+    }
+    has_added = true;
+    ss << entry.dump();
+  }
+  ss << "\n]\n";
+  return ss.str();
+}
+
+void CatapultRecorder::writeToFile(const std::string& file_path)
+{
+  const auto output = collectEvents();
+  std::ofstream out{file_path};
+  out << output;
+}
+
+CatapultRecorder::~CatapultRecorder()
+{
+  stop();
+  if (!dump_file_path_.empty())
+  {
+    writeToFile(dump_file_path_);
+  }
+}
+
+}  // namespace scalopus

--- a/scalopus_catapult/src/catapult_recorder.cpp
+++ b/scalopus_catapult/src/catapult_recorder.cpp
@@ -35,10 +35,10 @@ namespace scalopus
 {
 void CatapultRecorder::loop()
 {
-  while(running_)
+  while (running_)
   {
     {
-      std::lock_guard<std::mutex> lock{source_mutex_};
+      std::lock_guard<std::mutex> lock{ source_mutex_ };
       for (auto& source : sources_)
       {
         source->work();
@@ -58,10 +58,9 @@ void CatapultRecorder::stop()
   sources_.clear();
 }
 
-
 void CatapultRecorder::startInterval()
 {
-  std::lock_guard<std::mutex> lock{source_mutex_};
+  std::lock_guard<std::mutex> lock{ source_mutex_ };
   for (auto& source : sources_)
   {
     source->startInterval();
@@ -70,7 +69,7 @@ void CatapultRecorder::startInterval()
 
 void CatapultRecorder::stopInterval()
 {
-  std::lock_guard<std::mutex> lock{source_mutex_};
+  std::lock_guard<std::mutex> lock{ source_mutex_ };
   for (auto& source : sources_)
   {
     source->stopInterval();
@@ -97,15 +96,13 @@ void CatapultRecorder::start()
     sources_.push_back(provider->makeSource());
   }
   running_ = true;
-  worker_ = std::thread{[&]{loop();}};
+  worker_ = std::thread{ [&] { loop(); } };
 }
-
 
 void CatapultRecorder::setupDumpFile(const std::string& file_path)
 {
   dump_file_path_ = file_path;
 }
-
 
 std::string CatapultRecorder::collectEvents()
 {
@@ -115,7 +112,7 @@ std::string CatapultRecorder::collectEvents()
   // Then collect the events by calling finishInterval
   std::vector<json> events;
   {
-    std::lock_guard<std::mutex> lock{source_mutex_};
+    std::lock_guard<std::mutex> lock{ source_mutex_ };
     for (auto& source : sources_)
     {
       auto results = source->finishInterval();
@@ -143,7 +140,7 @@ std::string CatapultRecorder::collectEvents()
 void CatapultRecorder::writeToFile(const std::string& file_path)
 {
   const auto output = collectEvents();
-  std::ofstream out{file_path};
+  std::ofstream out{ file_path };
   out << output;
 }
 

--- a/scalopus_catapult/src/catapult_recorder.cpp
+++ b/scalopus_catapult/src/catapult_recorder.cpp
@@ -88,6 +88,7 @@ void CatapultRecorder::start()
   {
     return;
   }
+
   sources_.clear();
   sources_.reserve(providers_.size());
   // Add all the sources to the session

--- a/scalopus_catapult/src/scalopus_catapult_server.cpp
+++ b/scalopus_catapult/src/scalopus_catapult_server.cpp
@@ -40,8 +40,8 @@
 #include "scalopus_catapult/catapult_server.h"
 
 #include <chrono>
-#include <thread>
 #include <iostream>
+#include <thread>
 
 #include <signal.h>
 #include <cstdlib>

--- a/scalopus_examples/CMakeLists.txt
+++ b/scalopus_examples/CMakeLists.txt
@@ -68,3 +68,7 @@ add_executable(showcase_counters src/showcase_count_events.cpp)
 target_compile_options(showcase_counters PRIVATE ${SCALOPUS_COMPILE_OPTIONS})
 target_link_libraries(showcase_counters Scalopus::scalopus_tracing_native)
 
+# Example shows how to start a catapult recorder at the process start, writes the traces on shutdown.
+add_executable(embedded_catapult_recorder src/embedded_catapult_recorder.cpp)
+target_compile_options(embedded_catapult_recorder PRIVATE ${SCALOPUS_COMPILE_OPTIONS})
+target_link_libraries(embedded_catapult_recorder Scalopus::scalopus_catapult Scalopus::scalopus_tracing_native)

--- a/scalopus_examples/README.md
+++ b/scalopus_examples/README.md
@@ -35,6 +35,11 @@ This shows how one could embed the catapult server in the process that produces 
 built using the `native` tracing backend, because that's the only one that makes sense for such a usecase. I don't
 expect this use case to be particularly useful, but it's possible.
 
+## `embedded_catapult_recorder.cpp`
+This shows how one could embed the catapult recorder in the process that produces the tracepoints. This example is only
+built using the `native` tracing backend, because that's the only one that makes sense for such a usecase. This can be
+useful when measuring durations in short-lived programs, or when the full lifetime of the process needs to be captured.
+
 ## `query_servers.cpp`
 This results in a binary that will connect to all discovered servers and obtain the data provided through the introspect
 , process info and trace mapping endpoints. The binary outputs human readable text to `stderr` while it is working, at

--- a/scalopus_examples/src/embedded_catapult_recorder.cpp
+++ b/scalopus_examples/src/embedded_catapult_recorder.cpp
@@ -39,8 +39,8 @@
 
 // The catapult recorder side.
 #include <scalopus_catapult/catapult_recorder.h>
-#include <scalopus_general/general_provider.h>
 #include <scalopus_general/endpoint_manager_poll.h>
+#include <scalopus_general/general_provider.h>
 #include <scalopus_tracing/native_trace_provider.h>
 
 void c()
@@ -96,12 +96,12 @@ int main(int /* argc */, char** argv)
   logging_function("Logging can be enabled in the source, uncomment the lines below this one.");
 
   manager->connect(server->getAddress());  // Connect the manager to the server.
-  catapult_recorder->start();  // start the recorder thread.
-  catapult_recorder->startInterval();  // start recording.
+  catapult_recorder->start();              // start the recorder thread.
+  catapult_recorder->startInterval();      // start recording.
 
   TRACE_THREAD_NAME("main");
 
-  for (std::size_t i=0; i < 5; i++)
+  for (std::size_t i = 0; i < 5; i++)
   {
     a();
   }

--- a/scalopus_examples/src/embedded_catapult_recorder.cpp
+++ b/scalopus_examples/src/embedded_catapult_recorder.cpp
@@ -1,0 +1,114 @@
+/*
+  Copyright (c) 2018-2019, Ivor Wanders
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+  * Neither the name of the author nor the names of contributors may be used to
+    endorse or promote products derived from this software without specific
+    prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include <chrono>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <thread>
+
+// The producer side.
+#include <scalopus_tracing/tracing.h>
+#include <scalopus_transport/transport_loopback.h>
+
+// The catapult recorder side.
+#include <scalopus_catapult/catapult_recorder.h>
+#include <scalopus_general/general_provider.h>
+#include <scalopus_general/endpoint_manager_poll.h>
+#include <scalopus_tracing/native_trace_provider.h>
+
+void c()
+{
+  TRACE_PRETTY_FUNCTION();
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  std::cout << "  c" << std::endl;
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+}
+
+void b()
+{
+  TRACE_PRETTY_FUNCTION();
+  std::cout << " b" << std::endl;
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  c();
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+}
+
+void a()
+{
+  TRACE_PRETTY_FUNCTION();
+  std::cout << "a" << std::endl;
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  b();
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+}
+
+int main(int /* argc */, char** argv)
+{
+  // Client side to produce the tracepoints.
+  auto factory = std::make_shared<scalopus::TransportLoopbackFactory>();
+  const auto server = factory->serve();
+  server->addEndpoint(std::make_shared<scalopus::EndpointTraceMapping>());
+  server->addEndpoint(std::make_shared<scalopus::EndpointIntrospect>());
+  server->addEndpoint(std::make_shared<scalopus::EndpointNativeTraceSender>());
+  auto endpoint_process_info = std::make_shared<scalopus::EndpointProcessInfo>();
+  endpoint_process_info->setProcessName(argv[0]);
+  server->addEndpoint(endpoint_process_info);
+
+  // Catapult recorder side.
+  auto manager = std::make_shared<scalopus::EndpointManagerPoll>(factory);
+  manager->addEndpointFactory<scalopus::EndpointTraceMapping>();
+  manager->addEndpointFactory<scalopus::EndpointProcessInfo>();
+  auto native_trace_provider = std::make_shared<scalopus::NativeTraceProvider>(manager);
+  manager->addEndpointFactory(scalopus::EndpointNativeTraceSender::name, native_trace_provider);
+
+  auto catapult_recorder = std::make_shared<scalopus::CatapultRecorder>();
+  catapult_recorder->addProvider(native_trace_provider);
+  catapult_recorder->addProvider(std::make_shared<scalopus::GeneralProvider>(manager));
+
+  auto logging_function = [](const std::string& msg) { std::cout << msg << std::endl; };
+  logging_function("Logging can be enabled in the source, uncomment the lines below this one.");
+
+  manager->connect(server->getAddress());  // Connect the manager to the server.
+  catapult_recorder->start();  // start the recorder thread.
+  catapult_recorder->startInterval();  // start recording.
+
+  TRACE_THREAD_NAME("main");
+
+  for (std::size_t i=0; i < 5; i++)
+  {
+    a();
+  }
+  // need to guarantee we propagate the tracepoints before we stop the interval.
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  catapult_recorder->stopInterval();
+  catapult_recorder->setupDumpFile("/tmp/traces.json");
+
+  return 0;
+}

--- a/scalopus_general/include_consumer/scalopus_general/endpoint_manager_poll.h
+++ b/scalopus_general/include_consumer/scalopus_general/endpoint_manager_poll.h
@@ -65,6 +65,12 @@ public:
   void manage();
 
   /**
+   * @brief Connect to a specific destination, doesn't do anything if already connected to this destination. The caller
+   *        is responsible for ensuring the mutex for this objects' state is locked, or single threading is guaranteed.
+   */
+  void connect(const Destination::Ptr dest);
+
+  /**
    * @brief Return the map of the currently known endpoints.
    */
   virtual TransportEndpoints endpoints() const;

--- a/scalopus_interface/include/scalopus_interface/endpoint.h
+++ b/scalopus_interface/include/scalopus_interface/endpoint.h
@@ -88,7 +88,8 @@ public:
    */
   // static Endpoint::Ptr factory(const std::shared_ptr<Transport>& transport);
 protected:
-  Transport* transport_{ nullptr };  // Transport has a shared pointer to the endpoint, so it cannot go out of scope before this.
+  Transport* transport_{ nullptr };  // Transport has a shared pointer to the endpoint, so it cannot go out of scope
+                                     // before this.
 };
 
 }  // namespace scalopus

--- a/scalopus_tracing/include_consumer/scalopus_tracing/native_trace_provider.h
+++ b/scalopus_tracing/include_consumer/scalopus_tracing/native_trace_provider.h
@@ -86,7 +86,7 @@ private:
   std::mutex source_mutex_;
   std::set<std::shared_ptr<NativeTraceSource>> sources_;
 
-  LoggingFunction logger_;    //!< Function to use for logging.
+  LoggingFunction logger_;  //!< Function to use for logging.
 };
 
 }  // namespace scalopus

--- a/scalopus_tracing/src/native/tracepoint_collector_native.cpp
+++ b/scalopus_tracing/src/native/tracepoint_collector_native.cpp
@@ -68,7 +68,7 @@ tracepoint_collector_types::ScopeBufferPtr TracePointCollectorNative::getBuffer(
             // Do not check if it is empty, if for some reason tracepoints are still inserted into the buffer
             // by other thread_local's that have tracepoints, we will still be collecting them.
             {
-              std::lock_guard<std::mutex> lock{ptr->orphaned_mutex_};
+              std::lock_guard<std::mutex> lock{ ptr->orphaned_mutex_ };
               ptr->orphaned_tid_buffers_.emplace_back(tid, std::move(buffer));
             }
           }
@@ -105,7 +105,7 @@ TracePointCollectorNative::BufferMap::MapType TracePointCollectorNative::getActi
 TracePointCollectorNative::BufferVector TracePointCollectorNative::retrieveAndClearOrphanedBuffers()
 {
   BufferVector tmp;
-  std::lock_guard<std::mutex> lock{orphaned_mutex_};
+  std::lock_guard<std::mutex> lock{ orphaned_mutex_ };
   orphaned_tid_buffers_.swap(tmp);
   return tmp;
 }

--- a/scalopus_tracing/src/native/tracepoint_collector_native.h
+++ b/scalopus_tracing/src/native/tracepoint_collector_native.h
@@ -180,7 +180,7 @@ private:
    */
   BufferMap active_tid_buffers_;
 
-  mutable std::mutex orphaned_mutex_; //!< Mutex for the orphaned_tid_buffers_
+  mutable std::mutex orphaned_mutex_;  //!< Mutex for the orphaned_tid_buffers_
 
   /**
    * @brief Vector of orphaned buffers, any thread that has a ringbuffer and goes out of scope is moved to this

--- a/scalopus_tracing/test/test_native_tracepoints.cpp
+++ b/scalopus_tracing/test/test_native_tracepoints.cpp
@@ -216,6 +216,5 @@ int main(int /* argc */, char** /* argv */)
   test(result[0]["name"], "immediately_closing_thread");
   test(result[1]["name"], "immediately_closing_thread");
 
-
   return 0;
 }


### PR DESCRIPTION
This adds functionality to start a recording session and write to a file. Main use is from within a C++ application itself to record the entire lifespan and write a json file with traces on shutdown. See the `embedded_catapult_recorder` example.