### PR TITLE
Use find_package instead of include.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,28 +27,3 @@ jobs:
         run: |
           cd build
           ctest -VV .
-
-  build-1604:
-    name: Build and test 16.04
-    runs-on:  ubuntu-16.04
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          submodules: true
-      - name: Bootstrap
-        run: |
-          sudo apt-get install python3-setuptools
-      - name: mkdir build
-        run: mkdir build
-      - name: cmake ..
-        run: |
-          cd build
-          cmake  -D SCALOPUS_USE_PYTHON2=off -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-      - name: make
-        run: |
-          cd build
-          make
-      - name: ctest .
-        run: |
-          cd build
-          ctest -VV .

--- a/cmake/ScalopusConfig.cmake.in
+++ b/cmake/ScalopusConfig.cmake.in
@@ -33,7 +33,7 @@ else()
   list(REMOVE_AT CMAKE_PREFIX_PATH -1)
 endif()
 
-include(FindThreads)
+find_package(Threads REQUIRED)
 get_filename_component(Scalopus_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
 find_package(ScalopusInterface)


### PR DESCRIPTION
This resolves the cmake warnings we were getting in all downstream dependencies.

Please see internal ticket CORE-20202.

fyi @efernandez @jasonimercer @mikepurvis