### PR TITLE
Fix the catapult server for chrome 120

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ After building and succesfully being able to run the tests, use the following st
 [BabeltraceParser] Reached end of file, quiting parser function.
 [scalopus] Creating transport to: <unix:8343>
 ```
-3. Go go [`chrome://inspect?tracing`][chrome_tracing] (copy the link, clicking doesn't work), next to `Target (Scalopus Devtools Target)` click trace. You should now be in the tracing viewer and see `This about:tracing is connected to a remote device...` at the top. Click record, record, wait a bit and press stop.
+3. Go go [`chrome://inspect?tracing`][chrome_tracing] (copy the link, clicking doesn't work), right of `Target (120.0.6099.129)` click trace, there's a text arrow pointing at the correct `trace` button. You should now be in the tracing viewer and see `This about:tracing is connected to a remote device...` at the top. Click record, record, wait a bit and press stop.
 4. Profit.
 
 ## Legal

--- a/scalopus_catapult/README.md
+++ b/scalopus_catapult/README.md
@@ -60,3 +60,15 @@ babeltrace --clock-seconds --clock-gmt --no-delta --input-format=lttng-live lttn
 [seasocks]: https://github.com/mattgodbolt/seasocks/
 [lttng_view]: https://lttng.org/man/1/lttng-view/v2.10/
 [chrome_tracing]: chrome://inspect?tracing
+
+
+## Sniffing Google Chrome's traffic
+
+Things broke after the `120.0.6099.129` build, sniffing the communication can be done by running one browser that exposes
+the debugging port on `9222`;
+
+```
+google-chrome   --user-data-dir="$(mktemp -d)" --disable-extensions --remote-debugging-port=9222
+```
+
+Then we can connect to this from another browser, and at the same time have wireshark running on the loopback device.

--- a/scalopus_catapult/src/catapult_backend.cpp
+++ b/scalopus_catapult/src/catapult_backend.cpp
@@ -56,19 +56,19 @@ std::shared_ptr<ss::Response> CatapultBackend::handle(const ss::Request& request
   {
     // This URL is retrieved on the chrome://inspect?tracing page and it is the bold text.
     json j2 = {
-      { "Browser", "Scalopus Devtools Target" },
-      { "Protocol-Version", "1.2" },
-      { "User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu "
-                      "Chromium/64.0.3282.119 Chrome/64.0.3282.119 Safari/537.36" },
-      { "V8-Version", "6.4.388.40" },
-      { "WebKit-Version", "537.36 (@2ba93af511033c75c55cac08672b808e2c3fbe71)" },
+      { "Browser", "Chrome/120.0.6099.129" },
+      { "Protocol-Version", "1.3" },
+      { "User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+                      "Chrome/120.0.0.0 Safari/537.36" },
+      { "V8-Version", "12.0.267.10" },
+      { "WebKit-Version", "537.36 (@204016af461e03117aa3858b51ba4534c7cfda81)" },
       { "webSocketDebuggerUrl", "devtools/page/bar" },
     };
 
     return ss::Response::htmlResponse(j2.dump());
   }
 
-  if (request.getRequestUri() == "/json")
+  if (request.getRequestUri().rfind("/json/list", 0) == 0)  // check if string starts with this '/json/list?for_tab'
   {
     // This fakes a page display on this target, this makes it clear the target active and available.
     json j2 = { {
@@ -76,9 +76,10 @@ std::shared_ptr<ss::Response> CatapultBackend::handle(const ss::Request& request
         { "description", "Scalopus Operational" },
         { "devtoolsFrontendUrl", "/devtools/inspector.html?ws=127.0.0.1:9222/devtools/p" },
         { "id", "fooo" },
-        { "title", "click 'trace' -----------------------------------------^" },
-        { "type", "Scalopus remote tracing target" },
-        { "url", "z" },
+        { "title", "Scalopus; click 'trace' ---------------------------------------"
+                   "-----------------------------------^" },
+        { "type", "tab" },
+        { "url", "scalopus://catapult_server" },
         { "faviconUrl", DEVTOOLS_ENDPOINT_FAVICON },
         { "webSocketDebuggerUrl", "-" },
     } };


### PR DESCRIPTION
After working for over two year without any changes, the latest Chrome update resulted in the catapult server no longer being seen by Chrome.

This fixes that, also added docs on how to sniff the traffic on the 9222 port.