### PR TITLE
Add find_package(Python) to scalopus_python.

### DIFF
--- a/scalopus_python/CMakeLists.txt
+++ b/scalopus_python/CMakeLists.txt
@@ -1,3 +1,4 @@
+find_package (Python COMPONENTS Interpreter Development)
 
 if(NOT TARGET pybind11::pybind11)
   message(WARNING "Did not detect pybind11, skipping building the Python bindings.")


### PR DESCRIPTION
To ensure that `python_add_library` exists.

SES-5349

fyi @mikepurvis  @jasonimercer @efernandez 