### PR TITLE
Add missing header to fix compilation on gcc 13.2.

### DIFF
--- a/scalopus_interface/include/scalopus_interface/types.h
+++ b/scalopus_interface/include/scalopus_interface/types.h
@@ -30,6 +30,7 @@
 #ifndef SCALOPUS_INTERFACE_TYPES_H
 #define SCALOPUS_INTERFACE_TYPES_H
 
+#include <cstdint>
 #include <vector>
 #include "scalopus_interface/exceptions.h"
 


### PR DESCRIPTION
This header is missing, it's used 6 lines later, but apparently it was never a problem up til now.

Gcc 13.2 requires this fix though.

fyi @jasonimercer @efernandez  @mikepurvis 