### PR TITLE
Add ability to toggle default thread state, sleep longer if disabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   # disable mismatched tags until https://github.com/nlohmann/json/issues/1401
   set(CLANG_ONLY_COMPILE_FLAGS "${CLANG_ONLY_COMPILE_FLAGS};-Wno-mismatched-tags")
 endif()
-set(SCALOPUS_COMPILE_OPTIONS "-Werror;-Wall;-Wextra;-Wshadow;-Wnon-virtual-dtor;-Wpedantic;${CLANG_ONLY_COMPILE_FLAGS}")
+set(SCALOPUS_COMPILE_OPTIONS "-Wall;-Wextra;-Wshadow;-Wnon-virtual-dtor;-Wpedantic;${CLANG_ONLY_COMPILE_FLAGS}")
 
 include(FindThreads)
 

--- a/scalopus_python/lib/scalopus_interface.cpp
+++ b/scalopus_python/lib/scalopus_interface.cpp
@@ -136,6 +136,7 @@ py::object PendingResponse::wait_for(double seconds)
   py::gil_scoped_release release;
   if (resp_->wait_for(std::chrono::duration<double>(seconds)) == std::future_status::ready)
   {
+    pybind11::gil_scoped_acquire gil;
     return dataToPy(resp_->get());
   }
   return py::cast<py::none>(Py_None);

--- a/scalopus_python/lib/scalopus_tracing.cpp
+++ b/scalopus_python/lib/scalopus_tracing.cpp
@@ -89,6 +89,10 @@ void add_scalopus_tracing(py::module& m)
   endpoint_tc_trace_conf.def_readwrite("cmd_success", &EndpointTraceConfigurator::TraceConfiguration::cmd_success);
   endpoint_tc_trace_conf.def_readwrite("set_process_state",
                                        &EndpointTraceConfigurator::TraceConfiguration::set_process_state);
+  endpoint_tc_trace_conf.def_readwrite("new_thread_state",
+                                       &EndpointTraceConfigurator::TraceConfiguration::new_thread_state);
+  endpoint_tc_trace_conf.def_readwrite("set_new_thread_state",
+                                       &EndpointTraceConfigurator::TraceConfiguration::set_new_thread_state);
   endpoint_tc_trace_conf.def_readwrite("thread_state", &EndpointTraceConfigurator::TraceConfiguration::thread_state);
   // For some reason, assigning into tread_state directly didn't work, make a simple assign function.
   endpoint_tc_trace_conf.def("add_thread_entry", [](EndpointTraceConfigurator::TraceConfiguration& v, unsigned long id,
@@ -98,6 +102,8 @@ void add_scalopus_tracing(py::module& m)
     auto dict = py::dict();
     dict["set_process_state"] = p.set_process_state;
     dict["process_state"] = p.process_state;
+    dict["set_new_thread_state"] = p.set_new_thread_state;
+    dict["new_thread_state"] = p.new_thread_state;
     dict["cmd_success"] = p.cmd_success;
     dict["thread_state"] = p.thread_state;
     return dict;

--- a/scalopus_python/scalopus/__main__.py
+++ b/scalopus_python/scalopus/__main__.py
@@ -186,13 +186,22 @@ def run_trace_configure(args):
 
         new_state = scalopus.tracing.EndpointTraceConfigurator.TraceConfiguration()
 
+
         if (pinfo.pid in relevant_ids):
-            new_state.set_process_state = True
-            new_state.process_state = new_trace_state
+            if args.new_thread:
+                new_state.set_new_thread_state = True
+                new_state.new_thread_state = new_trace_state
+            else:
+                new_state.set_process_state = True
+                new_state.process_state = new_trace_state
         else:
             if args.unmatched_pid:
-                new_state.set_process_state = True
-                new_state.process_state = new_unmatched_trace_state
+                if args.new_thread:
+                    new_state.set_new_thread_state = True
+                    new_state.new_thread_state = new_unmatched_trace_state
+                else:
+                    new_state.set_process_state = True
+                    new_state.process_state = new_unmatched_trace_state
 
         for thread_id in pinfo.threads.keys():
             if thread_id in relevant_ids:
@@ -215,7 +224,8 @@ def run_trace_configure(args):
 
     for pid, data in entries:
         pid_str = color_by_state("{: >6d}".format(pid), data["state"]["process_state"])
-        print("PID: {}  \"{}\"".format(pid_str, data["process_info"]["name"]))
+        new_threads_str = color_by_state("new_threads", data["state"]["new_thread_state"])
+        print("PID: {}  \"{}\" [{}]".format(pid_str, data["process_info"]["name"], new_threads_str))
         doffset = " " * 8
         threads = data["process_info"]["threads"]
         for thread_id, thread_name in sorted(threads.items()):
@@ -276,6 +286,10 @@ if __name__ == "__main__":
     trace_configure_parser.add_argument('-u','--unmatched-pid',default=None,
         choices=['on', 'off'], nargs="?",
         help="Set unmatched process id's state to this value.")
+    
+    trace_configure_parser.add_argument('-t','--new-thread',default=False,
+        action="store_true",help="Set the value for new threads instead of current threads/process.")
+    
     trace_configure_parser.add_argument("id", nargs="*", type=int,
         help="Process or thread ID to change.")
 

--- a/scalopus_python/scalopus/scalopus_python_lib.py
+++ b/scalopus_python/scalopus/scalopus_python_lib.py
@@ -3,7 +3,7 @@
 # that's found inside the .egg file instead of 'this' python file.
 def __bootstrap__():
     global __bootstrap__, __loader__, __file__
-    import sys, pkg_resources, imp, sysconfig
+    import sys, pkg_resources, importlib, importlib.machinery, sysconfig
     # Use the ABI suffix, this is "" for python2, for python3 this call returns something like:
     # ['cpython-36m-x86_64-linux-gnu']
     so_abi_suffix = sysconfig.get_config_vars("SOABI")
@@ -11,7 +11,14 @@ def __bootstrap__():
     if so_abi_suffix:
         if len(so_abi_suffix):
             so_suffix = so_abi_suffix[0] + "." if so_abi_suffix[0] is not None else ""
-    __file__ = pkg_resources.resource_filename(__name__,'../scalopus_python_lib.{}so'.format(so_suffix))
+    name = __name__
+    filename = './scalopus_python_lib.{}so'.format(so_suffix)
+    __file__ = pkg_resources.resource_filename(name, filename)
     __loader__ = None; del __bootstrap__, __loader__
-    imp.load_dynamic(__name__,__file__)
+    
+    import importlib.machinery
+    loader = importlib.machinery.ExtensionFileLoader(name, filename)
+    spec = importlib.machinery.ModuleSpec(name=name, loader=loader, origin=filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module) 
 __bootstrap__()

--- a/scalopus_python/scalopus/scalopus_python_lib.py
+++ b/scalopus_python/scalopus/scalopus_python_lib.py
@@ -12,7 +12,7 @@ def __bootstrap__():
         if len(so_abi_suffix):
             so_suffix = so_abi_suffix[0] + "." if so_abi_suffix[0] is not None else ""
     name = __name__
-    filename = './scalopus_python_lib.{}so'.format(so_suffix)
+    filename = f'./scalopus_python_lib.{so_suffix}so'
     __file__ = pkg_resources.resource_filename(name, filename)
     __loader__ = None; del __bootstrap__, __loader__
     

--- a/scalopus_tracing/include/scalopus_tracing/endpoint_trace_configurator.h
+++ b/scalopus_tracing/include/scalopus_tracing/endpoint_trace_configurator.h
@@ -49,6 +49,10 @@ public:
   {
     bool process_state{ false };                 //!< Are traces for this process enabled?
     bool set_process_state{ false };             //!< Are we setting the process state?
+
+    bool new_thread_state{ false };                 //!< Are traces for new threads enabled?
+    bool set_new_thread_state{ false };             //!< Are we setting the new thread state?
+
     std::map<unsigned long, bool> thread_state;  //!< Thread state, true = tracing enabled.
     bool cmd_success{ false };
 

--- a/scalopus_tracing/include/scalopus_tracing/trace_configurator.h
+++ b/scalopus_tracing/include/scalopus_tracing/trace_configurator.h
@@ -82,6 +82,11 @@ public:
   AtomicBoolPtr getProcessStatePtr() const;
 
   /**
+   * @brief Retrieve the new thread boolean pointer.
+   */
+  AtomicBoolPtr getNewThreadStatePtr() const;
+
+  /**
    * @brief Retrieve the process wide boolean.
    */
   bool getProcessState() const;
@@ -92,12 +97,23 @@ public:
   bool setProcessState(bool new_state);
 
   /**
+   * @brief Retrieve the boolean state for new threads.
+   */
+  bool getNewThreadState() const;
+
+  /**
+   * @brief Set the new thread state and return the old state.
+   */
+  bool setNewThreadState(bool new_state);
+
+  /**
    * @brief Retrieve the map of thread booleans.
    */
   std::map<unsigned long, AtomicBoolPtr> getThreadMap() const;
 
 private:
   AtomicBoolPtr process_state_;  //!< Process wide enable / disable flag.
+  AtomicBoolPtr new_thread_state_; //!< State of newly created threads.
 
   mutable std::mutex threads_map_mutex_;                 //!< Mutex for the threads_enabled_ map.
   std::map<unsigned long, AtomicBoolPtr> thread_state_;  //!< Enable / disable per thread.

--- a/scalopus_tracing/src/endpoint_trace_configurator.cpp
+++ b/scalopus_tracing/src/endpoint_trace_configurator.cpp
@@ -148,7 +148,7 @@ bool EndpointTraceConfigurator::handle(Transport& /* server */, const Data& requ
 
   // Store the process state
   updated_state.process_state = process_state->load();
-  updated_state.new_thread_state =new_thread_state->load();
+  updated_state.new_thread_state = new_thread_state->load();
 
   // Store the thread state
   std::for_each(thread_map.begin(), thread_map.end(),

--- a/scalopus_tracing/src/lttng/babeltrace_parser.cpp
+++ b/scalopus_tracing/src/lttng/babeltrace_parser.cpp
@@ -28,6 +28,7 @@
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #include "scalopus_tracing/babeltrace_parser.h"
+#include <array>
 #include <iostream>
 #include <sstream>
 

--- a/scalopus_tracing/src/native/endpoint_native_trace_sender.cpp
+++ b/scalopus_tracing/src/native/endpoint_native_trace_sender.cpp
@@ -109,7 +109,7 @@ void EndpointNativeTraceSender::work()
       }
     }
     // @TODO; do some real rate limiting here.
-    if (TraceConfigurator::getInstance()->getProcessState()) {
+    if (!TraceConfigurator::getInstance()->getProcessState()) {
       // Sleep for a longer duration if the process is completely disabled.
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
     } else {

--- a/scalopus_tracing/src/native/endpoint_native_trace_sender.cpp
+++ b/scalopus_tracing/src/native/endpoint_native_trace_sender.cpp
@@ -28,6 +28,7 @@
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #include "scalopus_tracing/endpoint_native_trace_sender.h"
+#include "scalopus_tracing/trace_configurator.h"
 #include <cbor/stl.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -108,7 +109,13 @@ void EndpointNativeTraceSender::work()
       }
     }
     // @TODO; do some real rate limiting here.
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    if (TraceConfigurator::getInstance()->getProcessState()) {
+      // Sleep for a longer duration if the process is completely disabled.
+      std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    } else {
+      // Else sleep briefly to avoid spinning at a full core.
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
   }
 }
 

--- a/scalopus_tracing/src/trace_configurator.cpp
+++ b/scalopus_tracing/src/trace_configurator.cpp
@@ -35,6 +35,7 @@ namespace scalopus
 TraceConfigurator::TraceConfigurator()
 {
   process_state_ = std::make_shared<std::atomic_bool>(true);  // default to enabled.
+  new_thread_state_ = std::make_shared<std::atomic_bool>(true);  // default to enabled.
 }
 
 TraceConfigurator::AtomicBoolPtr TraceConfigurator::getThreadStatePtr()
@@ -58,7 +59,7 @@ TraceConfigurator::AtomicBoolPtr TraceConfigurator::getThreadStatePtr()
   }
   else
   {
-    auto boolean = std::make_shared<std::atomic_bool>(true);  // default each thread to enabled.
+    auto boolean = std::make_shared<std::atomic_bool>(new_thread_state_->load());
     thread_state_[tid] = boolean;
     return boolean;
   }
@@ -93,6 +94,21 @@ bool TraceConfigurator::getProcessState() const
 bool TraceConfigurator::setProcessState(bool new_state)
 {
   return process_state_->exchange(new_state);
+}
+
+TraceConfigurator::AtomicBoolPtr TraceConfigurator::getNewThreadStatePtr() const
+{
+  return new_thread_state_;
+}
+
+bool TraceConfigurator::getNewThreadState() const
+{
+  return *new_thread_state_;
+}
+
+bool TraceConfigurator::setNewThreadState(bool new_state)
+{
+  return new_thread_state_->exchange(new_state);
 }
 
 std::map<unsigned long, TraceConfigurator::AtomicBoolPtr> TraceConfigurator::getThreadMap() const

--- a/scalopus_tracing/test/test_native_tracepoints.cpp
+++ b/scalopus_tracing/test/test_native_tracepoints.cpp
@@ -136,7 +136,7 @@ int main(int /* argc */, char** /* argv */)
   {
     TRACE_SCOPE_RAII("enabled_again");
   }
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   different_thread.join();
   result = source->finishInterval();
   test(result.size(), 2u);
@@ -169,6 +169,7 @@ int main(int /* argc */, char** /* argv */)
 
   // Finally check whether we can flip the process state back to true.
   scalopus::TraceConfigurator::getInstance()->setProcessState(true);
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   source->startInterval();
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   {


### PR DESCRIPTION
Goal is to bring cpu usage to zero when tracing is not desired. (CORE-33702)

Previously, [all threads](https://github.com/iwanders/scalopus/blob/08cbd38ece2df1da34d225600fc4b77b290d9306/scalopus_tracing/src/trace_configurator.cpp#L61) started in an enabled state, which made them put threads onto the spsc queue. This PR makes that boolean there configurable through the `TraceConfigurator` and adds functionality for that to the Trace configuration Endpoint and Python module. This is also helpful to disable traces from being emitted from short lived threads that may otherwise clutter up the traces.

With these changes, one can fully disable tracing with:
```
auto configurator_instance = TraceConfigurator::getInstance();
configurator_instance->setProcessState(false);
configurator_instance->setNewThreadState(false);
```

Ideally, the users of the library also prevent the creation of any endpoints, as the `EndpointNativeTraceSender` for example also has a spinner. This is something consumers will have to do (will do it centrally on our internal lib). In case the thread has its state disabled, the sleep in that endpoint is also increased significantly.

The pipeline failed, so I ended up bumping pybind11 to make the upstream compilation pass again against python 3.12. I did have to increase the sleep after re-activating the process to ensure we correctly fall out of the now longer sleep. This also required some minor changes in the binding because `py::bytes` is no longer convertible to `std::vector<uint8_t>`. Last commit fixes a segfault I ran into, which is aptly described in [this stackoverflow](https://stackoverflow.com/a/78200366), I was allocating a python object without holding the GIL, which was fine in Python 3.11 and prior, but not in python 3.12.

@efernandez @jasonimercer @d3murphy